### PR TITLE
feat(#4): design system — theme, colors, typography, components

### DIFF
--- a/idea-pilot/idea-pilot/Core/Components/DesignSystemPreview.swift
+++ b/idea-pilot/idea-pilot/Core/Components/DesignSystemPreview.swift
@@ -1,0 +1,169 @@
+//
+//  DesignSystemPreview.swift
+//  idea-pilot
+//
+//  Preview-only gallery of all design system tokens and components.
+//  Open this file in Xcode Previews for visual verification.
+//
+
+import SwiftUI
+
+// MARK: - Design System Gallery Preview
+
+#Preview("Design System Gallery") {
+    ScrollView {
+        VStack(alignment: .leading, spacing: 32) {
+
+            // MARK: Colors
+
+            sectionHeader("Colors")
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 80))], spacing: 8) {
+                colorSwatch("bg", Color.theme.background)
+                colorSwatch("card", Color.theme.card)
+                colorSwatch("popover", Color.theme.popover)
+                colorSwatch("secondary", Color.theme.secondary)
+                colorSwatch("muted", Color.theme.muted)
+                colorSwatch("primary", Color.theme.primary)
+                colorSwatch("accent", Color.theme.accent)
+                colorSwatch("destructive", Color.theme.destructive)
+                colorSwatch("border", Color.theme.border)
+                colorSwatch("ring", Color.theme.ring)
+            }
+
+            // MARK: Typography
+
+            sectionHeader("Typography")
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Large Title").font(.theme.largeTitle)
+                Text("Title").font(.theme.title)
+                Text("Title 2").font(.theme.title2)
+                Text("Title 3").font(.theme.title3)
+                Text("Body").font(.theme.body)
+                Text("Body Regular").font(.theme.bodyRegular)
+                Text("Subheadline").font(.theme.subheadline)
+                Text("Caption").font(.theme.caption)
+                Text("OVERLINE").font(.theme.overline)
+                Text("Badge").font(.theme.badge)
+                Text("1234567890").font(.theme.captionTabular)
+            }
+            .foregroundStyle(Color.theme.foreground)
+
+            // MARK: Phase Badges
+
+            sectionHeader("Phase Badges")
+            HStack(spacing: 8) {
+                ForEach(PhaseBadge.Phase.allCases, id: \.self) { phase in
+                    PhaseBadge(phase: phase)
+                }
+            }
+
+            // MARK: Lane Chips
+
+            sectionHeader("Lane Chips")
+            LaneChipGroup(selected: .constant(.now))
+
+            // MARK: Time Estimate Pills
+
+            sectionHeader("Time Estimates")
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Display mode").font(.theme.caption).foregroundStyle(Color.theme.mutedForeground)
+                HStack(spacing: 8) {
+                    TimeEstimatePill(minutes: 30)
+                    TimeEstimatePill(minutes: 60)
+                    TimeEstimatePill(minutes: 90)
+                    TimeEstimatePill(minutes: 120)
+                }
+                Text("Selected mode").font(.theme.caption).foregroundStyle(Color.theme.mutedForeground)
+                HStack(spacing: 8) {
+                    TimeEstimatePill(minutes: 30)
+                    TimeEstimatePill(minutes: 60, isSelected: true)
+                    TimeEstimatePill(minutes: 90)
+                    TimeEstimatePill(minutes: 120)
+                }
+            }
+
+            // MARK: Card Style
+
+            sectionHeader("Card Style")
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Task Title Here")
+                    .font(.theme.body)
+                    .foregroundStyle(.white)
+                Text("Secondary info")
+                    .font(.theme.subheadline)
+                    .foregroundStyle(Color.theme.mutedForeground)
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .cardStyle()
+
+            // MARK: Button Styles
+
+            sectionHeader("Press Feedback")
+            Button {} label: {
+                Text("Pressable Button")
+                    .font(.theme.body)
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+                    .background(Color.theme.primary)
+                    .clipShape(RoundedRectangle(cornerRadius: .theme.radiusLg))
+            }
+            .buttonStyle(.pressable)
+
+            Button {} label: {
+                Text("Destructive Button")
+                    .font(.theme.body)
+                    .foregroundStyle(Color.theme.destructive)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: .theme.radiusLg)
+                            .stroke(Color.theme.destructive.opacity(0.2), lineWidth: 1)
+                    )
+            }
+            .buttonStyle(.pressable)
+
+            // MARK: Glass Effect
+
+            sectionHeader("Glass Effect")
+            HStack {
+                Spacer()
+                Text("Tab Bar Glass")
+                    .font(.theme.caption)
+                    .foregroundStyle(.white)
+                Spacer()
+            }
+            .padding(.vertical, 12)
+            .glassStyle()
+            .clipShape(RoundedRectangle(cornerRadius: .theme.radiusLg))
+        }
+        .padding(20)
+    }
+    .themeBackground()
+}
+
+// MARK: - Preview Helpers
+
+@ViewBuilder
+private func sectionHeader(_ title: String) -> some View {
+    Text(title.uppercased())
+        .font(.theme.overline)
+        .foregroundStyle(Color.theme.mutedForeground)
+}
+
+@ViewBuilder
+private func colorSwatch(_ name: String, _ color: Color) -> some View {
+    VStack(spacing: 4) {
+        RoundedRectangle(cornerRadius: 8)
+            .fill(color)
+            .frame(height: 44)
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color.white.opacity(0.2), lineWidth: 1)
+            )
+        Text(name)
+            .font(.system(size: 9))
+            .foregroundStyle(Color.theme.mutedForeground)
+    }
+}

--- a/idea-pilot/idea-pilot/Core/Components/LaneChip.swift
+++ b/idea-pilot/idea-pilot/Core/Components/LaneChip.swift
@@ -1,0 +1,93 @@
+//
+//  LaneChip.swift
+//  idea-pilot
+//
+//  A selectable chip for task lane (NOW / NEXT / LATER).
+//
+
+import SwiftUI
+
+/// A horizontal set of selectable lane chips for task lane assignment.
+///
+/// Used in Quick Add (CaptureSheet) and Task Detail for lane selection.
+/// The selected chip has a filled white background; unselected chips have
+/// a muted secondary background.
+///
+/// Usage:
+/// ```swift
+/// LaneChipGroup(selected: $selectedLane)
+/// ```
+struct LaneChipGroup: View {
+
+    /// The task lane options.
+    ///
+    /// This enum will be replaced by the domain model enum in Issue #5.
+    enum Lane: String, CaseIterable, Sendable {
+        case now = "NOW"
+        case next = "NEXT"
+        case later = "LATER"
+    }
+
+    @Binding var selected: Lane
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ForEach(Lane.allCases, id: \.self) { lane in
+                LaneChip(
+                    lane: lane,
+                    isSelected: selected == lane,
+                    action: { selected = lane }
+                )
+            }
+        }
+    }
+}
+
+/// A single lane chip button.
+///
+/// When selected: white background, black text, white border.
+/// When unselected: secondary/muted background, muted text, no border.
+struct LaneChip: View {
+
+    let lane: LaneChipGroup.Lane
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(lane.rawValue)
+                .font(.theme.caption)
+                .fontWeight(.semibold)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 10)
+                .foregroundStyle(isSelected ? Color.black : Color.theme.mutedForeground)
+                .background(isSelected ? Color.white : Color.theme.secondary.opacity(0.5))
+                .clipShape(RoundedRectangle(cornerRadius: .theme.radiusSm))
+                .overlay(
+                    RoundedRectangle(cornerRadius: .theme.radiusSm)
+                        .stroke(isSelected ? Color.white : Color.clear, lineWidth: 1)
+                )
+        }
+        .buttonStyle(.pressable)
+        .accessibilityLabel("\(lane.rawValue) lane")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}
+
+#Preview("Lane Chips") {
+    struct PreviewWrapper: View {
+        @State private var lane: LaneChipGroup.Lane = .later
+
+        var body: some View {
+            VStack(spacing: 16) {
+                Text("Selected: \(lane.rawValue)")
+                    .font(.theme.body)
+                    .foregroundStyle(.white)
+                LaneChipGroup(selected: $lane)
+            }
+            .padding()
+            .themeBackground()
+        }
+    }
+    return PreviewWrapper()
+}

--- a/idea-pilot/idea-pilot/Core/Components/PhaseBadge.swift
+++ b/idea-pilot/idea-pilot/Core/Components/PhaseBadge.swift
@@ -1,0 +1,69 @@
+//
+//  PhaseBadge.swift
+//  idea-pilot
+//
+//  A colored badge indicating a playbook's lifecycle phase.
+//
+
+import SwiftUI
+
+/// Displays a playbook's lifecycle phase as a small colored pill badge.
+///
+/// Each phase (PROOF, STRUCTURE, REPEATABILITY, GROWTH) has a distinct color.
+/// The badge uses a tinted background with matching text and border.
+///
+/// Usage:
+/// ```swift
+/// PhaseBadge(phase: .proof)
+/// ```
+struct PhaseBadge: View {
+
+    /// The playbook lifecycle phases.
+    ///
+    /// Each phase maps to a distinct color from the design system.
+    /// This enum will be replaced by the domain model enum in Issue #5.
+    enum Phase: String, CaseIterable, Sendable {
+        case proof = "PROOF"
+        case structure = "STRUCTURE"
+        case repeatability = "REPEATABILITY"
+        case growth = "GROWTH"
+
+        /// The display color for this phase.
+        var color: Color {
+            switch self {
+            case .proof:         return Color.theme.phaseProof
+            case .structure:     return Color.theme.phaseStructure
+            case .repeatability: return Color.theme.phaseRepeatability
+            case .growth:        return Color.theme.phaseGrowth
+            }
+        }
+    }
+
+    let phase: Phase
+
+    var body: some View {
+        Text(phase.rawValue)
+            .font(.theme.badge)
+            .tracking(1.0)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .foregroundStyle(phase.color)
+            .background(phase.color.opacity(0.1))
+            .clipShape(Capsule())
+            .overlay(
+                Capsule()
+                    .stroke(phase.color.opacity(0.2), lineWidth: 1)
+            )
+            .accessibilityLabel("Phase: \(phase.rawValue.capitalized)")
+    }
+}
+
+#Preview("All Phases") {
+    VStack(spacing: 12) {
+        ForEach(PhaseBadge.Phase.allCases, id: \.self) { phase in
+            PhaseBadge(phase: phase)
+        }
+    }
+    .padding()
+    .themeBackground()
+}

--- a/idea-pilot/idea-pilot/Core/Components/TimeEstimatePill.swift
+++ b/idea-pilot/idea-pilot/Core/Components/TimeEstimatePill.swift
@@ -1,0 +1,118 @@
+//
+//  TimeEstimatePill.swift
+//  idea-pilot
+//
+//  A pill-shaped badge displaying a task's time estimate.
+//
+
+import SwiftUI
+
+/// Displays a task's estimated duration as a compact pill badge.
+///
+/// Shows the value in minutes with an "m" suffix (e.g., "90m").
+/// Supports two visual modes:
+/// - **Display mode** (default): muted neutral style, used on task cards.
+/// - **Selected mode**: primary-tinted, used in estimate pickers.
+///
+/// Usage:
+/// ```swift
+/// TimeEstimatePill(minutes: 90)
+/// TimeEstimatePill(minutes: 120, isSelected: true)
+/// ```
+struct TimeEstimatePill: View {
+
+    /// The estimated duration in minutes.
+    let minutes: Int
+
+    /// Whether this pill is in a selected state (e.g., in an estimate picker).
+    var isSelected: Bool = false
+
+    var body: some View {
+        Text("\(minutes)m")
+            .font(.theme.captionTabular)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .foregroundStyle(foregroundColor)
+            .background(backgroundColor)
+            .clipShape(RoundedRectangle(cornerRadius: .theme.radiusSm))
+            .overlay(
+                RoundedRectangle(cornerRadius: .theme.radiusSm)
+                    .stroke(borderColor, lineWidth: 1)
+            )
+            .accessibilityLabel("\(minutes) minutes estimated")
+    }
+
+    private var foregroundColor: Color {
+        isSelected ? Color.theme.primary : Color.theme.mutedForeground
+    }
+
+    private var backgroundColor: Color {
+        isSelected ? Color.theme.primary.opacity(0.2) : Color.theme.secondary
+    }
+
+    private var borderColor: Color {
+        isSelected ? Color.theme.primary.opacity(0.5) : Color.clear
+    }
+}
+
+/// A horizontal row of time estimate options for selection.
+///
+/// Used in Quick Add and Task Detail sheets for selecting task duration.
+/// Default options are 30, 60, 90, 120, and 180 minutes.
+///
+/// Usage:
+/// ```swift
+/// TimeEstimatePickerRow(selected: $estimate)
+/// ```
+struct TimeEstimatePickerRow: View {
+
+    @Binding var selected: Int
+
+    /// Available time options in minutes.
+    let options: [Int]
+
+    init(selected: Binding<Int>, options: [Int] = [30, 60, 90, 120, 180]) {
+        self._selected = selected
+        self.options = options
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ForEach(options, id: \.self) { mins in
+                Button {
+                    selected = mins
+                } label: {
+                    TimeEstimatePill(minutes: mins, isSelected: selected == mins)
+                }
+                .buttonStyle(.pressable)
+            }
+        }
+    }
+}
+
+#Preview("Time Estimate Pills") {
+    struct PreviewWrapper: View {
+        @State private var estimate = 60
+
+        var body: some View {
+            VStack(spacing: 24) {
+                Text("Display mode (task card)")
+                    .font(.theme.caption)
+                    .foregroundStyle(Color.theme.mutedForeground)
+                HStack(spacing: 8) {
+                    TimeEstimatePill(minutes: 30)
+                    TimeEstimatePill(minutes: 90)
+                    TimeEstimatePill(minutes: 120)
+                }
+
+                Text("Picker mode (selected: \(estimate)m)")
+                    .font(.theme.caption)
+                    .foregroundStyle(Color.theme.mutedForeground)
+                TimeEstimatePickerRow(selected: $estimate)
+            }
+            .padding()
+            .themeBackground()
+        }
+    }
+    return PreviewWrapper()
+}

--- a/idea-pilot/idea-pilot/Core/Extensions/Color+Theme.swift
+++ b/idea-pilot/idea-pilot/Core/Extensions/Color+Theme.swift
@@ -1,0 +1,157 @@
+//
+//  Color+Theme.swift
+//  idea-pilot
+//
+//  Design system color tokens.
+//  Source of truth: docs/design/Dark-Theme-Design/client/src/index.css
+//
+
+import SwiftUI
+
+// MARK: - HSL to SwiftUI Color Helper
+
+extension Color {
+
+    /// Creates a Color from CSS-style HSL values.
+    ///
+    /// - Parameters:
+    ///   - hue: Hue angle in degrees (0–360)
+    ///   - saturation: Saturation percentage (0–100)
+    ///   - lightness: Lightness percentage (0–100)
+    ///   - opacity: Opacity (0–1, default 1)
+    fileprivate static func hsl(
+        _ hue: Double,
+        _ saturation: Double,
+        _ lightness: Double,
+        opacity: Double = 1
+    ) -> Color {
+        let h = hue / 360.0
+        let s = saturation / 100.0
+        let l = lightness / 100.0
+
+        let brightness = l + s * min(l, 1 - l)
+        let hsbSaturation = brightness == 0 ? 0 : 2 * (1 - l / brightness)
+
+        return Color(
+            hue: h,
+            saturation: hsbSaturation,
+            brightness: brightness,
+            opacity: opacity
+        )
+    }
+}
+
+// MARK: - Theme Color Namespace
+
+extension Color {
+
+    /// Design system color tokens for Idea Pilot.
+    ///
+    /// All values derived from the Dark Future iOS theme CSS variables.
+    /// Usage: `Color.theme.primary`, `Color.theme.background`, etc.
+    enum theme {
+
+        // MARK: Surfaces
+
+        /// Pure black background. CSS: `0 0% 0%`
+        static let background = Color.black
+
+        /// Pure white foreground text. CSS: `0 0% 100%`
+        static let foreground = Color.white
+
+        /// Dark gray card surface. CSS: `240 5% 8%`
+        static let card = Color.hsl(240, 5, 8)
+
+        /// Card foreground (white). CSS: `0 0% 100%`
+        static let cardForeground = Color.white
+
+        /// Popover/sheet surface. CSS: `240 5% 10%`
+        static let popover = Color.hsl(240, 5, 10)
+
+        /// Popover foreground (white). CSS: `0 0% 100%`
+        static let popoverForeground = Color.white
+
+        // MARK: Brand
+
+        /// Electric blue/purple primary. CSS: `250 100% 65%`
+        static let primary = Color.hsl(250, 100, 65)
+
+        /// Primary foreground (white). CSS: `0 0% 100%`
+        static let primaryForeground = Color.white
+
+        /// Neon green accent for completion/success. CSS: `150 100% 50%`
+        static let accent = Color.hsl(150, 100, 50)
+
+        /// Accent foreground (black for contrast). CSS: `0 0% 0%`
+        static let accentForeground = Color.black
+
+        // MARK: Neutrals
+
+        /// Secondary surface. CSS: `240 5% 15%`
+        static let secondary = Color.hsl(240, 5, 15)
+
+        /// Secondary foreground (white). CSS: `0 0% 100%`
+        static let secondaryForeground = Color.white
+
+        /// Muted surface (same as secondary). CSS: `240 5% 15%`
+        static let muted = Color.hsl(240, 5, 15)
+
+        /// Muted/disabled text. CSS: `240 5% 65%`
+        static let mutedForeground = Color.hsl(240, 5, 65)
+
+        // MARK: Semantic
+
+        /// Destructive red for delete/cancel actions. CSS: `0 100% 60%`
+        static let destructive = Color.hsl(0, 100, 60)
+
+        /// Destructive foreground (white). CSS: `0 0% 100%`
+        static let destructiveForeground = Color.white
+
+        // MARK: Borders & Focus
+
+        /// Default border color. CSS: `240 5% 15%`
+        static let border = Color.hsl(240, 5, 15)
+
+        /// Input field border. CSS: `240 5% 15%`
+        static let input = Color.hsl(240, 5, 15)
+
+        /// Focus ring color. CSS: `250 100% 65%`
+        static let ring = Color.hsl(250, 100, 65)
+
+        // MARK: Phase Badge Colors
+
+        /// PROOF phase — blue
+        static let phaseProof = Color.blue
+
+        /// STRUCTURE phase — purple
+        static let phaseStructure = Color.purple
+
+        /// REPEATABILITY phase — orange
+        static let phaseRepeatability = Color.orange
+
+        /// GROWTH phase — green
+        static let phaseGrowth = Color.green
+    }
+}
+
+// MARK: - Theme Radius Tokens
+
+extension CGFloat {
+
+    /// Design system corner radius tokens.
+    ///
+    /// Derived from CSS `--radius: 1rem` (16pt).
+    enum theme {
+        /// Small radius: 12pt. CSS: `calc(var(--radius) - 4px)`
+        static let radiusSm: CGFloat = 12
+
+        /// Medium radius: 14pt. CSS: `calc(var(--radius) - 2px)`
+        static let radiusMd: CGFloat = 14
+
+        /// Large radius (base): 16pt. CSS: `var(--radius)`
+        static let radiusLg: CGFloat = 16
+
+        /// Extra-large radius: 20pt. CSS: `calc(var(--radius) + 4px)`
+        static let radiusXl: CGFloat = 20
+    }
+}

--- a/idea-pilot/idea-pilot/Core/Extensions/Font+Theme.swift
+++ b/idea-pilot/idea-pilot/Core/Extensions/Font+Theme.swift
@@ -1,0 +1,76 @@
+//
+//  Font+Theme.swift
+//  idea-pilot
+//
+//  Design system typography tokens.
+//  Maps the web mockup's Inter type scale to SF Pro (iOS system font).
+//
+
+import SwiftUI
+
+extension Font {
+
+    /// Design system typography tokens for Idea Pilot.
+    ///
+    /// All sizes use SF Pro (system font). The web mockup uses Inter which
+    /// has nearly identical metrics to SF Pro.
+    ///
+    /// Usage: `.font(.theme.title)`, `.font(.theme.body)`, etc.
+    enum theme {
+
+        // MARK: Display
+
+        /// Large display heading. 34pt bold.
+        /// Used for: auth screen title, large page titles.
+        static let largeTitle: Font = .system(size: 34, weight: .bold)
+
+        /// Screen title. 28pt bold.
+        /// Used for: "Playbooks" list header, section headers.
+        static let title: Font = .system(size: 28, weight: .bold)
+
+        /// Secondary title. 22pt semibold.
+        /// Used for: playbook name on home screen, sheet titles.
+        static let title2: Font = .system(size: 22, weight: .semibold)
+
+        /// Tertiary title. 20pt semibold.
+        /// Used for: card headings, empty state titles.
+        static let title3: Font = .system(size: 20, weight: .semibold)
+
+        // MARK: Body
+
+        /// Primary body text. 17pt medium.
+        /// Used for: task card titles, form labels.
+        static let body: Font = .system(size: 17, weight: .medium)
+
+        /// Regular body text. 17pt regular.
+        /// Used for: section content, notes, input text.
+        static let bodyRegular: Font = .system(size: 17, weight: .regular)
+
+        /// Secondary text. 15pt regular.
+        /// Used for: task summaries, secondary descriptions.
+        static let subheadline: Font = .system(size: 15, weight: .regular)
+
+        // MARK: Captions & Labels
+
+        /// Small caption. 13pt medium.
+        /// Used for: time badges, lane counts, metadata.
+        static let caption: Font = .system(size: 13, weight: .medium)
+
+        /// Overline label. 11pt bold, intended for uppercased text.
+        /// Used for: form field labels ("LANE", "ESTIMATE").
+        static let overline: Font = .system(size: 11, weight: .bold)
+
+        /// Badge text. 10pt bold.
+        /// Used for: PhaseBadge, small status indicators.
+        static let badge: Font = .system(size: 10, weight: .bold)
+
+        // MARK: Tabular Figures
+
+        /// Tabular (monospaced digits) caption for numeric display.
+        /// Prevents layout shifts when values change (e.g., "90m" vs "120m").
+        static let captionTabular: Font = .system(size: 13, weight: .semibold).monospacedDigit()
+
+        /// Tabular body for larger numeric display.
+        static let bodyTabular: Font = .system(size: 17, weight: .medium).monospacedDigit()
+    }
+}

--- a/idea-pilot/idea-pilot/Core/Extensions/View+Theme.swift
+++ b/idea-pilot/idea-pilot/Core/Extensions/View+Theme.swift
@@ -1,0 +1,114 @@
+//
+//  View+Theme.swift
+//  idea-pilot
+//
+//  Design system view modifiers and button styles.
+//
+
+import SwiftUI
+
+// MARK: - Press Feedback Button Style
+
+/// A button style that applies a subtle scale-down spring animation on press.
+///
+/// Matches the web mockup's `active:scale-[0.98]` interaction pattern.
+/// Used for all tappable cards, primary buttons, and interactive elements.
+///
+/// Usage:
+/// ```swift
+/// Button("Tap me") { ... }
+///     .buttonStyle(.pressable)
+/// ```
+struct PressableButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.98 : 1.0)
+            .animation(.spring(response: 0.3, dampingFraction: 0.7), value: configuration.isPressed)
+    }
+}
+
+extension ButtonStyle where Self == PressableButtonStyle {
+    /// A button style with subtle press-down spring feedback (scale 0.98).
+    static var pressable: PressableButtonStyle { PressableButtonStyle() }
+}
+
+// MARK: - Card Style Modifier
+
+/// Applies the standard card appearance: dark card background, subtle border,
+/// rounded corners.
+///
+/// Matches the recurring `bg-card border border-white/5 rounded-2xl` pattern
+/// from the web mockup.
+struct CardModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .background(Color.theme.card)
+            .clipShape(RoundedRectangle(cornerRadius: .theme.radiusLg))
+            .overlay(
+                RoundedRectangle(cornerRadius: .theme.radiusLg)
+                    .stroke(Color.white.opacity(0.05), lineWidth: 1)
+            )
+    }
+}
+
+extension View {
+    /// Applies the Idea Pilot card style: dark background, subtle border, rounded corners.
+    func cardStyle() -> some View {
+        modifier(CardModifier())
+    }
+}
+
+// MARK: - Glass Effect Modifier
+
+/// Applies the iOS glass morphism effect used for the tab bar and overlays.
+///
+/// Matches the web mockup's `.ios-glass` class:
+/// `bg-black/70 backdrop-blur-xl border-t border-white/10`
+struct GlassModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .background(.ultraThinMaterial)
+            .background(Color.black.opacity(0.7))
+            .overlay(alignment: .top) {
+                Rectangle()
+                    .fill(Color.white.opacity(0.1))
+                    .frame(height: 0.5)
+            }
+    }
+}
+
+extension View {
+    /// Applies the glass-effect style with blur and subtle top border.
+    func glassStyle() -> some View {
+        modifier(GlassModifier())
+    }
+}
+
+// MARK: - Reduce Motion Support
+
+extension View {
+    /// Conditionally applies an animation, respecting the Reduce Motion accessibility setting.
+    ///
+    /// When Reduce Motion is enabled, animations are replaced with instant transitions.
+    ///
+    /// - Parameter animation: The animation to apply when Reduce Motion is off.
+    func motionSafe(_ animation: Animation) -> some View {
+        transaction { transaction in
+            if UIAccessibility.isReduceMotionEnabled {
+                transaction.animation = nil
+            } else {
+                transaction.animation = animation
+            }
+        }
+    }
+}
+
+// MARK: - Theme Background
+
+extension View {
+    /// Applies the app's pure black background extending into safe areas.
+    func themeBackground() -> some View {
+        self
+            .background(Color.theme.background.ignoresSafeArea())
+    }
+}

--- a/idea-pilot/idea-pilot/Navigation/RootView.swift
+++ b/idea-pilot/idea-pilot/Navigation/RootView.swift
@@ -17,22 +17,21 @@ import SwiftUI
 struct RootView: View {
     var body: some View {
         ZStack {
-            Color.black
+            Color.theme.background
                 .ignoresSafeArea()
 
             VStack(spacing: 16) {
                 Image(systemName: "airplane")
                     .font(.system(size: 64))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(Color.theme.foreground)
 
                 Text("Idea Pilot")
-                    .font(.largeTitle)
-                    .fontWeight(.bold)
-                    .foregroundStyle(.white)
+                    .font(.theme.largeTitle)
+                    .foregroundStyle(Color.theme.foreground)
 
                 Text("Helping you land on the tarmac of execution")
-                    .font(.subheadline)
-                    .foregroundStyle(.white.opacity(0.6))
+                    .font(.theme.subheadline)
+                    .foregroundStyle(Color.theme.mutedForeground)
             }
         }
     }


### PR DESCRIPTION
## Summary
- **Color tokens** (`Color.theme.*`): full dark theme palette translated from CSS HSL values — surfaces, brand, semantic, borders, phase colors, corner radii
- **Typography** (`Font.theme.*`): SF Pro scale mapping from Inter mockup — display, body, caption, overline, badge, tabular figures
- **View modifiers**: `.pressable` button style (scale 0.98 spring), `.cardStyle()`, `.glassStyle()`, `.motionSafe()`, `.themeBackground()`
- **Reusable components**: `PhaseBadge`, `LaneChipGroup`/`LaneChip`, `TimeEstimatePill`/`TimeEstimatePickerRow`
- **Preview gallery**: `DesignSystemPreview.swift` for visual verification in Xcode
- **Integration**: `RootView.swift` updated to use design system tokens

## Files Added/Modified
- `Core/Extensions/Color+Theme.swift` — color tokens + HSL helper
- `Core/Extensions/Font+Theme.swift` — typography scale
- `Core/Extensions/View+Theme.swift` — modifiers + button styles
- `Core/Components/PhaseBadge.swift` — phase badge component
- `Core/Components/LaneChip.swift` — lane selector chips
- `Core/Components/TimeEstimatePill.swift` — time estimate badges
- `Core/Components/DesignSystemPreview.swift` — preview gallery
- `Navigation/RootView.swift` — updated to use theme tokens

## Test plan
- [x] `xcodebuild build` — BUILD SUCCEEDED
- [x] `xcodebuild build-for-testing` — TEST BUILD SUCCEEDED
- [ ] Open `DesignSystemPreview.swift` in Xcode Previews for visual verification
- [ ] Open each component preview to verify rendering

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)