### PR TITLE
#5 SwiftData domain models (Playbook, Task, Section, WeeklyCycle, User)

### DIFF
--- a/idea-pilot/idea-pilot.xcodeproj/project.pbxproj
+++ b/idea-pilot/idea-pilot.xcodeproj/project.pbxproj
@@ -400,7 +400,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = BDE57K9ZHX;
 				ENABLE_PREVIEWS = YES;
-				EXCLUDED_SOURCE_FILE_NAMES = ".gitkeep";
+				EXCLUDED_SOURCE_FILE_NAMES = .gitkeep;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -434,7 +434,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = BDE57K9ZHX;
 				ENABLE_PREVIEWS = YES;
-				EXCLUDED_SOURCE_FILE_NAMES = ".gitkeep";
+				EXCLUDED_SOURCE_FILE_NAMES = .gitkeep;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/idea-pilot/idea-pilot/App/idea_pilotApp.swift
+++ b/idea-pilot/idea-pilot/App/idea_pilotApp.swift
@@ -5,13 +5,16 @@
 //  Created by Harold Bostic on 2/21/26.
 //
 
+import SwiftData
 import SwiftUI
 
 /// The main entry point for the Idea Pilot iOS app.
 ///
-/// This struct bootstraps the app window and sets the root view.
+/// Bootstraps the app window, registers the SwiftData `ModelContainer`,
+/// and sets the root view. SwiftData discovers all related models
+/// (TaskModel, SectionModel, WeeklyCycleModel) via PlaybookModel's relationships.
+///
 /// Future milestones will add:
-/// - `ModelContainer` for SwiftData persistence (Issue #5)
 /// - Environment objects for auth state and sync engine
 /// - Deep link handling
 @main
@@ -20,5 +23,6 @@ struct idea_pilotApp: App {
         WindowGroup {
             RootView()
         }
+        .modelContainer(for: PlaybookModel.self)
     }
 }

--- a/idea-pilot/idea-pilot/Core/Components/DesignSystemPreview.swift
+++ b/idea-pilot/idea-pilot/Core/Components/DesignSystemPreview.swift
@@ -52,7 +52,7 @@ import SwiftUI
 
             sectionHeader("Phase Badges")
             HStack(spacing: 8) {
-                ForEach(PhaseBadge.Phase.allCases, id: \.self) { phase in
+                ForEach(PlaybookPhase.allCases, id: \.self) { phase in
                     PhaseBadge(phase: phase)
                 }
             }

--- a/idea-pilot/idea-pilot/Core/Components/LaneChip.swift
+++ b/idea-pilot/idea-pilot/Core/Components/LaneChip.swift
@@ -19,20 +19,11 @@ import SwiftUI
 /// ```
 struct LaneChipGroup: View {
 
-    /// The task lane options.
-    ///
-    /// This enum will be replaced by the domain model enum in Issue #5.
-    enum Lane: String, CaseIterable, Sendable {
-        case now = "NOW"
-        case next = "NEXT"
-        case later = "LATER"
-    }
-
-    @Binding var selected: Lane
+    @Binding var selected: TaskLane
 
     var body: some View {
         HStack(spacing: 8) {
-            ForEach(Lane.allCases, id: \.self) { lane in
+            ForEach(TaskLane.allCases, id: \.self) { lane in
                 LaneChip(
                     lane: lane,
                     isSelected: selected == lane,
@@ -49,7 +40,7 @@ struct LaneChipGroup: View {
 /// When unselected: secondary/muted background, muted text, no border.
 struct LaneChip: View {
 
-    let lane: LaneChipGroup.Lane
+    let lane: TaskLane
     let isSelected: Bool
     let action: () -> Void
 
@@ -76,7 +67,7 @@ struct LaneChip: View {
 
 #Preview("Lane Chips") {
     struct PreviewWrapper: View {
-        @State private var lane: LaneChipGroup.Lane = .later
+        @State private var lane: TaskLane = .later
 
         var body: some View {
             VStack(spacing: 16) {

--- a/idea-pilot/idea-pilot/Core/Components/PhaseBadge.swift
+++ b/idea-pilot/idea-pilot/Core/Components/PhaseBadge.swift
@@ -9,8 +9,8 @@ import SwiftUI
 
 /// Displays a playbook's lifecycle phase as a small colored pill badge.
 ///
-/// Each phase (PROOF, STRUCTURE, REPEATABILITY, GROWTH) has a distinct color.
-/// The badge uses a tinted background with matching text and border.
+/// Each phase (PROOF, STRUCTURE, REPEATABILITY, GROWTH) has a distinct color
+/// defined on the `PlaybookPhase` enum.
 ///
 /// Usage:
 /// ```swift
@@ -18,28 +18,7 @@ import SwiftUI
 /// ```
 struct PhaseBadge: View {
 
-    /// The playbook lifecycle phases.
-    ///
-    /// Each phase maps to a distinct color from the design system.
-    /// This enum will be replaced by the domain model enum in Issue #5.
-    enum Phase: String, CaseIterable, Sendable {
-        case proof = "PROOF"
-        case structure = "STRUCTURE"
-        case repeatability = "REPEATABILITY"
-        case growth = "GROWTH"
-
-        /// The display color for this phase.
-        var color: Color {
-            switch self {
-            case .proof:         return Color.theme.phaseProof
-            case .structure:     return Color.theme.phaseStructure
-            case .repeatability: return Color.theme.phaseRepeatability
-            case .growth:        return Color.theme.phaseGrowth
-            }
-        }
-    }
-
-    let phase: Phase
+    let phase: PlaybookPhase
 
     var body: some View {
         Text(phase.rawValue)
@@ -60,7 +39,7 @@ struct PhaseBadge: View {
 
 #Preview("All Phases") {
     VStack(spacing: 12) {
-        ForEach(PhaseBadge.Phase.allCases, id: \.self) { phase in
+        ForEach(PlaybookPhase.allCases, id: \.self) { phase in
             PhaseBadge(phase: phase)
         }
     }

--- a/idea-pilot/idea-pilot/Models/Enums.swift
+++ b/idea-pilot/idea-pilot/Models/Enums.swift
@@ -1,0 +1,68 @@
+//
+//  Enums.swift
+//  idea-pilot
+//
+//  Domain enums for Playbook phase, Task lane/status, and Section type.
+//  Raw values match the backend API contract.
+//
+
+import SwiftUI
+
+// MARK: - Playbook Phase
+
+/// The lifecycle phase of a Playbook.
+///
+/// Projects progress sequentially: prove the idea manually, formalize what worked,
+/// make it teachable/delegable, then scale.
+///
+/// Raw values match the backend API: `"PROOF"`, `"STRUCTURE"`, etc.
+enum PlaybookPhase: String, Codable, Hashable, CaseIterable, Sendable {
+    case proof = "PROOF"
+    case structure = "STRUCTURE"
+    case repeatability = "REPEATABILITY"
+    case growth = "GROWTH"
+
+    /// The design system color for this phase.
+    var color: Color {
+        switch self {
+        case .proof:         return Color.theme.phaseProof
+        case .structure:     return Color.theme.phaseStructure
+        case .repeatability: return Color.theme.phaseRepeatability
+        case .growth:        return Color.theme.phaseGrowth
+        }
+    }
+}
+
+// MARK: - Task Lane
+
+/// The execution lane for a Task.
+///
+/// - `now`: Active tasks (daily focus, 3–5 max)
+/// - `next`: Upcoming tasks
+/// - `later`: Backlog / idea parking lot
+enum TaskLane: String, Codable, Hashable, CaseIterable, Sendable {
+    case now = "NOW"
+    case next = "NEXT"
+    case later = "LATER"
+}
+
+// MARK: - Task Status
+
+/// The completion status of a Task.
+enum TaskStatus: String, Codable, Hashable, CaseIterable, Sendable {
+    case open = "OPEN"
+    case done = "DONE"
+}
+
+// MARK: - Section Type
+
+/// The type of an immutable Playbook section.
+///
+/// Each Playbook has exactly one of each section type.
+/// Content is rich text edited by the user.
+enum SectionType: String, Codable, Hashable, CaseIterable, Sendable {
+    case vision = "VISION"
+    case system = "SYSTEM"
+    case build = "BUILD"
+    case businessModel = "BUSINESS_MODEL"
+}

--- a/idea-pilot/idea-pilot/Models/PlaybookModel.swift
+++ b/idea-pilot/idea-pilot/Models/PlaybookModel.swift
@@ -1,0 +1,79 @@
+//
+//  PlaybookModel.swift
+//  idea-pilot
+//
+//  SwiftData model for a Playbook — the top-level project container.
+//
+
+import Foundation
+import SwiftData
+
+/// A project container that holds vision, system, build sections and executable tasks.
+///
+/// Each Playbook progresses through lifecycle phases (PROOF → STRUCTURE → REPEATABILITY → GROWTH)
+/// and contains tasks organized into NOW/NEXT/LATER lanes.
+///
+/// Relationships:
+/// - One-to-many with `TaskModel` (cascade delete)
+/// - One-to-many with `SectionModel` (cascade delete)
+/// - One-to-many with `WeeklyCycleModel` (cascade delete)
+@Model
+final class PlaybookModel {
+
+    /// Server-assigned unique identifier.
+    @Attribute(.unique) var id: String
+
+    /// The playbook's display title.
+    var title: String
+
+    /// Optional longer description of the playbook's purpose.
+    var descriptionText: String?
+
+    /// The current lifecycle phase, stored as its raw string value.
+    var phaseRawValue: String
+
+    /// Whether this playbook has been archived by the user.
+    var isArchived: Bool
+
+    var createdAt: Date
+    var updatedAt: Date
+
+    /// All tasks belonging to this playbook.
+    @Relationship(deleteRule: .cascade, inverse: \TaskModel.playbook)
+    var tasks: [TaskModel]
+
+    /// The immutable sections (Vision, System, Build, Business Model).
+    @Relationship(deleteRule: .cascade, inverse: \SectionModel.playbook)
+    var sections: [SectionModel]
+
+    /// Weekly planning cycles for this playbook.
+    @Relationship(deleteRule: .cascade, inverse: \WeeklyCycleModel.playbook)
+    var weeklyCycles: [WeeklyCycleModel]
+
+    /// The current lifecycle phase.
+    var phase: PlaybookPhase {
+        get { PlaybookPhase(rawValue: phaseRawValue) ?? .proof }
+        set { phaseRawValue = newValue.rawValue }
+    }
+
+    init(
+        id: String = UUID().uuidString,
+        title: String,
+        descriptionText: String? = nil,
+        phase: PlaybookPhase = .proof,
+        isArchived: Bool = false,
+        createdAt: Date = .now,
+        updatedAt: Date = .now
+    ) {
+        self.id = id
+        self.title = title
+        self.descriptionText = descriptionText
+        self.phaseRawValue = phase.rawValue
+        self.isArchived = isArchived
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.tasks = []
+        self.sections = []
+        self.weeklyCycles = []
+    }
+}

--- a/idea-pilot/idea-pilot/Models/SectionModel.swift
+++ b/idea-pilot/idea-pilot/Models/SectionModel.swift
@@ -1,0 +1,55 @@
+//
+//  SectionModel.swift
+//  idea-pilot
+//
+//  SwiftData model for a Section — a structured content block within a Playbook.
+//
+
+import Foundation
+import SwiftData
+
+/// A structured content section belonging to a Playbook.
+///
+/// Each Playbook has one section per `SectionType` (Vision, System, Build, Business Model).
+/// The `compositeId` uniquely identifies a section as `"{playbookId}_{sectionType}"`.
+///
+/// Relationship: belongs to one `PlaybookModel`.
+@Model
+final class SectionModel {
+
+    /// Composite unique key: `"{playbookId}_{sectionType}"`.
+    @Attribute(.unique) var compositeId: String
+
+    /// The ID of the parent playbook (denormalized for queries).
+    var playbookId: String
+
+    /// The section type, stored as its raw string value.
+    var sectionTypeRawValue: String
+
+    /// The rich text content of this section.
+    var content: String
+
+    var updatedAt: Date
+
+    /// The parent playbook.
+    var playbook: PlaybookModel?
+
+    /// The section type (VISION/SYSTEM/BUILD/BUSINESS_MODEL).
+    var sectionType: SectionType {
+        get { SectionType(rawValue: sectionTypeRawValue) ?? .vision }
+        set { sectionTypeRawValue = newValue.rawValue }
+    }
+
+    init(
+        playbookId: String,
+        sectionType: SectionType,
+        content: String = "",
+        updatedAt: Date = .now
+    ) {
+        self.compositeId = "\(playbookId)_\(sectionType.rawValue)"
+        self.playbookId = playbookId
+        self.sectionTypeRawValue = sectionType.rawValue
+        self.content = content
+        self.updatedAt = updatedAt
+    }
+}

--- a/idea-pilot/idea-pilot/Models/TaskModel.swift
+++ b/idea-pilot/idea-pilot/Models/TaskModel.swift
@@ -1,0 +1,90 @@
+//
+//  TaskModel.swift
+//  idea-pilot
+//
+//  SwiftData model for a Task — an executable work item within a Playbook.
+//
+
+import Foundation
+import SwiftData
+
+/// An executable work item belonging to a Playbook.
+///
+/// Tasks are organized into lanes (NOW/NEXT/LATER) and must be sized between
+/// 30–180 minutes. The `orderIndex` determines display order within a lane.
+///
+/// Relationship: belongs to one `PlaybookModel`.
+@Model
+final class TaskModel {
+
+    /// Server-assigned unique identifier.
+    @Attribute(.unique) var id: String
+
+    /// The ID of the parent playbook (denormalized for queries).
+    var playbookId: String
+
+    /// The task's display title.
+    var title: String
+
+    /// Optional longer description or notes.
+    var detail: String?
+
+    /// The execution lane, stored as its raw string value.
+    var laneRawValue: String
+
+    /// Estimated duration in minutes (30–180).
+    var estimatedMinutes: Int
+
+    /// The completion status, stored as its raw string value.
+    var statusRawValue: String
+
+    /// Display order within the lane (0-indexed).
+    var orderIndex: Int
+
+    /// When the task was marked as done.
+    var completedAt: Date?
+
+    var createdAt: Date
+    var updatedAt: Date
+
+    /// The parent playbook.
+    var playbook: PlaybookModel?
+
+    /// The execution lane (NOW/NEXT/LATER).
+    var lane: TaskLane {
+        get { TaskLane(rawValue: laneRawValue) ?? .later }
+        set { laneRawValue = newValue.rawValue }
+    }
+
+    /// The completion status (OPEN/DONE).
+    var status: TaskStatus {
+        get { TaskStatus(rawValue: statusRawValue) ?? .open }
+        set { statusRawValue = newValue.rawValue }
+    }
+
+    init(
+        id: String = UUID().uuidString,
+        playbookId: String,
+        title: String,
+        detail: String? = nil,
+        lane: TaskLane = .later,
+        estimatedMinutes: Int = 60,
+        status: TaskStatus = .open,
+        orderIndex: Int = 0,
+        completedAt: Date? = nil,
+        createdAt: Date = .now,
+        updatedAt: Date = .now
+    ) {
+        self.id = id
+        self.playbookId = playbookId
+        self.title = title
+        self.detail = detail
+        self.laneRawValue = lane.rawValue
+        self.estimatedMinutes = estimatedMinutes
+        self.statusRawValue = status.rawValue
+        self.orderIndex = orderIndex
+        self.completedAt = completedAt
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}

--- a/idea-pilot/idea-pilot/Models/UserSession.swift
+++ b/idea-pilot/idea-pilot/Models/UserSession.swift
@@ -1,0 +1,29 @@
+//
+//  UserSession.swift
+//  idea-pilot
+//
+//  Lightweight struct representing the authenticated user's session.
+//  Stored in Keychain (not SwiftData) via TokenManager (Issue #7).
+//
+
+import Foundation
+
+/// The authenticated user's session data.
+///
+/// This is a plain value type — not a SwiftData `@Model` — because auth tokens
+/// belong in the Keychain, not in the local database. `TokenManager` (Issue #7)
+/// will handle serialization and secure storage.
+nonisolated struct UserSession: Codable, Sendable, Equatable {
+
+    /// The user's server-assigned identifier.
+    let userId: String
+
+    /// The user's email address.
+    let email: String
+
+    /// JWT access token for API requests.
+    let accessToken: String
+
+    /// Refresh token for obtaining new access tokens.
+    let refreshToken: String
+}

--- a/idea-pilot/idea-pilot/Models/WeeklyCycleModel.swift
+++ b/idea-pilot/idea-pilot/Models/WeeklyCycleModel.swift
@@ -1,0 +1,58 @@
+//
+//  WeeklyCycleModel.swift
+//  idea-pilot
+//
+//  SwiftData model for a WeeklyCycle — a weekly planning snapshot for a Playbook.
+//
+
+import Foundation
+import SwiftData
+
+/// A weekly planning cycle snapshot belonging to a Playbook.
+///
+/// Tracks how many tasks were planned vs. completed for a given week.
+/// Used by the Weekly Plan ritual flow and progress dashboards.
+///
+/// Relationship: belongs to one `PlaybookModel`.
+@Model
+final class WeeklyCycleModel {
+
+    /// Server-assigned unique identifier.
+    @Attribute(.unique) var id: String
+
+    /// The ID of the parent playbook (denormalized for queries).
+    var playbookId: String
+
+    /// The Monday start date of this planning week.
+    var weekStartDate: Date
+
+    /// Number of tasks completed this week.
+    var completedCount: Int
+
+    /// Total number of tasks planned for this week.
+    var totalCount: Int
+
+    var createdAt: Date
+    var updatedAt: Date
+
+    /// The parent playbook.
+    var playbook: PlaybookModel?
+
+    init(
+        id: String = UUID().uuidString,
+        playbookId: String,
+        weekStartDate: Date,
+        completedCount: Int = 0,
+        totalCount: Int = 0,
+        createdAt: Date = .now,
+        updatedAt: Date = .now
+    ) {
+        self.id = id
+        self.playbookId = playbookId
+        self.weekStartDate = weekStartDate
+        self.completedCount = completedCount
+        self.totalCount = totalCount
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}

--- a/idea-pilot/idea-pilotTests/ModelTests.swift
+++ b/idea-pilot/idea-pilotTests/ModelTests.swift
@@ -1,0 +1,500 @@
+//
+//  ModelTests.swift
+//  idea-pilotTests
+//
+//  Unit tests for SwiftData domain models and enums.
+//
+
+import Foundation
+import SwiftData
+import Testing
+@testable import idea_pilot
+
+// MARK: - Enum Tests
+
+@Suite("PlaybookPhase")
+struct PlaybookPhaseTests {
+
+    @Test("raw values match API contract")
+    func rawValues() {
+        #expect(PlaybookPhase.proof.rawValue == "PROOF")
+        #expect(PlaybookPhase.structure.rawValue == "STRUCTURE")
+        #expect(PlaybookPhase.repeatability.rawValue == "REPEATABILITY")
+        #expect(PlaybookPhase.growth.rawValue == "GROWTH")
+    }
+
+    @Test("CaseIterable returns all four phases")
+    func allCases() {
+        #expect(PlaybookPhase.allCases.count == 4)
+    }
+
+    @Test("Codable roundtrip")
+    func codableRoundtrip() throws {
+        for phase in PlaybookPhase.allCases {
+            let data = try JSONEncoder().encode(phase)
+            let decoded = try JSONDecoder().decode(PlaybookPhase.self, from: data)
+            #expect(decoded == phase)
+        }
+    }
+}
+
+@Suite("TaskLane")
+struct TaskLaneTests {
+
+    @Test("raw values match API contract")
+    func rawValues() {
+        #expect(TaskLane.now.rawValue == "NOW")
+        #expect(TaskLane.next.rawValue == "NEXT")
+        #expect(TaskLane.later.rawValue == "LATER")
+    }
+
+    @Test("CaseIterable returns all three lanes")
+    func allCases() {
+        #expect(TaskLane.allCases.count == 3)
+    }
+
+    @Test("Codable roundtrip")
+    func codableRoundtrip() throws {
+        for lane in TaskLane.allCases {
+            let data = try JSONEncoder().encode(lane)
+            let decoded = try JSONDecoder().decode(TaskLane.self, from: data)
+            #expect(decoded == lane)
+        }
+    }
+}
+
+@Suite("TaskStatus")
+struct TaskStatusTests {
+
+    @Test("raw values match API contract")
+    func rawValues() {
+        #expect(TaskStatus.open.rawValue == "OPEN")
+        #expect(TaskStatus.done.rawValue == "DONE")
+    }
+
+    @Test("CaseIterable returns both statuses")
+    func allCases() {
+        #expect(TaskStatus.allCases.count == 2)
+    }
+
+    @Test("Codable roundtrip")
+    func codableRoundtrip() throws {
+        for status in TaskStatus.allCases {
+            let data = try JSONEncoder().encode(status)
+            let decoded = try JSONDecoder().decode(TaskStatus.self, from: data)
+            #expect(decoded == status)
+        }
+    }
+}
+
+@Suite("SectionType")
+struct SectionTypeTests {
+
+    @Test("raw values match API contract")
+    func rawValues() {
+        #expect(SectionType.vision.rawValue == "VISION")
+        #expect(SectionType.system.rawValue == "SYSTEM")
+        #expect(SectionType.build.rawValue == "BUILD")
+        #expect(SectionType.businessModel.rawValue == "BUSINESS_MODEL")
+    }
+
+    @Test("CaseIterable returns all four types")
+    func allCases() {
+        #expect(SectionType.allCases.count == 4)
+    }
+
+    @Test("Codable roundtrip")
+    func codableRoundtrip() throws {
+        for sType in SectionType.allCases {
+            let data = try JSONEncoder().encode(sType)
+            let decoded = try JSONDecoder().decode(SectionType.self, from: data)
+            #expect(decoded == sType)
+        }
+    }
+}
+
+@Suite("UserSession")
+struct UserSessionTests {
+
+    @Test("Codable roundtrip")
+    func codableRoundtrip() throws {
+        let session = UserSession(
+            userId: "user-123",
+            email: "test@example.com",
+            accessToken: "access-xyz",
+            refreshToken: "refresh-abc"
+        )
+        let data = try JSONEncoder().encode(session)
+        let decoded = try JSONDecoder().decode(UserSession.self, from: data)
+        #expect(decoded == session)
+    }
+}
+
+// MARK: - Model Tests
+
+/// Creates an in-memory ModelContainer for testing.
+@MainActor
+private func makeTestContainer() throws -> ModelContainer {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    return try ModelContainer(
+        for: PlaybookModel.self, TaskModel.self, SectionModel.self, WeeklyCycleModel.self,
+        configurations: config
+    )
+}
+
+@Suite("PlaybookModel CRUD", .serialized)
+@MainActor
+struct PlaybookModelTests {
+
+    @Test("create and fetch")
+    func createAndFetch() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let playbook = PlaybookModel(id: "pb-1", title: "Launch MVP", phase: .proof)
+        context.insert(playbook)
+        try context.save()
+
+        let descriptor = FetchDescriptor<PlaybookModel>()
+        let results = try context.fetch(descriptor)
+        #expect(results.count == 1)
+        #expect(results[0].title == "Launch MVP")
+        #expect(results[0].phase == .proof)
+        #expect(results[0].isArchived == false)
+    }
+
+    @Test("update fields")
+    func updateFields() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let playbook = PlaybookModel(id: "pb-2", title: "Old Title", phase: .proof)
+        context.insert(playbook)
+        try context.save()
+
+        playbook.title = "New Title"
+        playbook.phase = .structure
+        try context.save()
+
+        let descriptor = FetchDescriptor<PlaybookModel>()
+        let results = try context.fetch(descriptor)
+        #expect(results[0].title == "New Title")
+        #expect(results[0].phase == .structure)
+    }
+
+    @Test("delete")
+    func delete() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let playbook = PlaybookModel(id: "pb-3", title: "To Delete")
+        context.insert(playbook)
+        try context.save()
+
+        context.delete(playbook)
+        try context.save()
+
+        let descriptor = FetchDescriptor<PlaybookModel>()
+        let results = try context.fetch(descriptor)
+        #expect(results.isEmpty)
+    }
+}
+
+@Suite("TaskModel CRUD", .serialized)
+@MainActor
+struct TaskModelTests {
+
+    @Test("create and fetch")
+    func createAndFetch() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let task = TaskModel(
+            id: "t-1",
+            playbookId: "pb-1",
+            title: "Write tests",
+            lane: .now,
+            estimatedMinutes: 90,
+            status: .open
+        )
+        context.insert(task)
+        try context.save()
+
+        let descriptor = FetchDescriptor<TaskModel>()
+        let results = try context.fetch(descriptor)
+        #expect(results.count == 1)
+        #expect(results[0].title == "Write tests")
+        #expect(results[0].lane == .now)
+        #expect(results[0].estimatedMinutes == 90)
+        #expect(results[0].status == .open)
+    }
+
+    @Test("update status to done")
+    func updateStatus() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let task = TaskModel(id: "t-2", playbookId: "pb-1", title: "Task")
+        context.insert(task)
+        try context.save()
+
+        task.status = .done
+        task.completedAt = .now
+        try context.save()
+
+        let descriptor = FetchDescriptor<TaskModel>()
+        let results = try context.fetch(descriptor)
+        #expect(results[0].status == .done)
+        #expect(results[0].completedAt != nil)
+    }
+
+    @Test("delete")
+    func delete() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let task = TaskModel(id: "t-3", playbookId: "pb-1", title: "To Delete")
+        context.insert(task)
+        try context.save()
+
+        context.delete(task)
+        try context.save()
+
+        let descriptor = FetchDescriptor<TaskModel>()
+        let results = try context.fetch(descriptor)
+        #expect(results.isEmpty)
+    }
+}
+
+@Suite("SectionModel CRUD", .serialized)
+@MainActor
+struct SectionModelTests {
+
+    @Test("create and fetch")
+    func createAndFetch() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let section = SectionModel(
+            playbookId: "pb-1",
+            sectionType: .vision,
+            content: "Build the best app"
+        )
+        context.insert(section)
+        try context.save()
+
+        let descriptor = FetchDescriptor<SectionModel>()
+        let results = try context.fetch(descriptor)
+        #expect(results.count == 1)
+        #expect(results[0].sectionType == .vision)
+        #expect(results[0].content == "Build the best app")
+        #expect(results[0].compositeId == "pb-1_VISION")
+    }
+
+    @Test("update content")
+    func updateContent() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let section = SectionModel(playbookId: "pb-1", sectionType: .build, content: "v1")
+        context.insert(section)
+        try context.save()
+
+        section.content = "v2 — updated"
+        try context.save()
+
+        let descriptor = FetchDescriptor<SectionModel>()
+        let results = try context.fetch(descriptor)
+        #expect(results[0].content == "v2 — updated")
+    }
+
+    @Test("delete")
+    func delete() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let section = SectionModel(playbookId: "pb-1", sectionType: .system)
+        context.insert(section)
+        try context.save()
+
+        context.delete(section)
+        try context.save()
+
+        let descriptor = FetchDescriptor<SectionModel>()
+        let results = try context.fetch(descriptor)
+        #expect(results.isEmpty)
+    }
+}
+
+@Suite("WeeklyCycleModel CRUD", .serialized)
+@MainActor
+struct WeeklyCycleModelTests {
+
+    @Test("create and fetch")
+    func createAndFetch() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let cycle = WeeklyCycleModel(
+            id: "wc-1",
+            playbookId: "pb-1",
+            weekStartDate: Date(timeIntervalSince1970: 1_700_000_000),
+            completedCount: 3,
+            totalCount: 5
+        )
+        context.insert(cycle)
+        try context.save()
+
+        let descriptor = FetchDescriptor<WeeklyCycleModel>()
+        let results = try context.fetch(descriptor)
+        #expect(results.count == 1)
+        #expect(results[0].completedCount == 3)
+        #expect(results[0].totalCount == 5)
+    }
+
+    @Test("delete")
+    func delete() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let cycle = WeeklyCycleModel(
+            id: "wc-2",
+            playbookId: "pb-1",
+            weekStartDate: .now
+        )
+        context.insert(cycle)
+        try context.save()
+
+        context.delete(cycle)
+        try context.save()
+
+        let descriptor = FetchDescriptor<WeeklyCycleModel>()
+        let results = try context.fetch(descriptor)
+        #expect(results.isEmpty)
+    }
+}
+
+@Suite("Model Relationships", .serialized)
+@MainActor
+struct RelationshipTests {
+
+    @Test("playbook → tasks relationship")
+    func playbookTasks() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let playbook = PlaybookModel(id: "pb-rel-1", title: "Rel Test")
+        context.insert(playbook)
+
+        let task = TaskModel(id: "t-rel-1", playbookId: "pb-rel-1", title: "Task 1")
+        task.playbook = playbook
+        context.insert(task)
+        try context.save()
+
+        #expect(playbook.tasks.count == 1)
+        #expect(task.playbook?.id == "pb-rel-1")
+    }
+
+    @Test("playbook → sections relationship")
+    func playbookSections() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let playbook = PlaybookModel(id: "pb-rel-2", title: "Sections Test")
+        context.insert(playbook)
+
+        let section = SectionModel(playbookId: "pb-rel-2", sectionType: .vision, content: "Vision text")
+        section.playbook = playbook
+        context.insert(section)
+        try context.save()
+
+        #expect(playbook.sections.count == 1)
+        #expect(section.playbook?.id == "pb-rel-2")
+    }
+
+    @Test("playbook → weeklyCycles relationship")
+    func playbookWeeklyCycles() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let playbook = PlaybookModel(id: "pb-rel-3", title: "Cycles Test")
+        context.insert(playbook)
+
+        let cycle = WeeklyCycleModel(id: "wc-rel-1", playbookId: "pb-rel-3", weekStartDate: .now)
+        cycle.playbook = playbook
+        context.insert(cycle)
+        try context.save()
+
+        #expect(playbook.weeklyCycles.count == 1)
+        #expect(cycle.playbook?.id == "pb-rel-3")
+    }
+
+    @Test("cascade delete removes tasks")
+    func cascadeDeleteTasks() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let playbook = PlaybookModel(id: "pb-cas-1", title: "Cascade Test")
+        context.insert(playbook)
+
+        let task1 = TaskModel(id: "t-cas-1", playbookId: "pb-cas-1", title: "Task A")
+        task1.playbook = playbook
+        context.insert(task1)
+
+        let task2 = TaskModel(id: "t-cas-2", playbookId: "pb-cas-1", title: "Task B")
+        task2.playbook = playbook
+        context.insert(task2)
+        try context.save()
+
+        #expect(playbook.tasks.count == 2)
+
+        context.delete(playbook)
+        try context.save()
+
+        let taskDescriptor = FetchDescriptor<TaskModel>()
+        let remainingTasks = try context.fetch(taskDescriptor)
+        #expect(remainingTasks.isEmpty)
+    }
+
+    @Test("cascade delete removes sections")
+    func cascadeDeleteSections() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let playbook = PlaybookModel(id: "pb-cas-2", title: "Cascade Sections")
+        context.insert(playbook)
+
+        let section = SectionModel(playbookId: "pb-cas-2", sectionType: .build, content: "Content")
+        section.playbook = playbook
+        context.insert(section)
+        try context.save()
+
+        context.delete(playbook)
+        try context.save()
+
+        let sectionDescriptor = FetchDescriptor<SectionModel>()
+        let remainingSections = try context.fetch(sectionDescriptor)
+        #expect(remainingSections.isEmpty)
+    }
+
+    @Test("cascade delete removes weekly cycles")
+    func cascadeDeleteCycles() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let playbook = PlaybookModel(id: "pb-cas-3", title: "Cascade Cycles")
+        context.insert(playbook)
+
+        let cycle = WeeklyCycleModel(id: "wc-cas-1", playbookId: "pb-cas-3", weekStartDate: .now)
+        cycle.playbook = playbook
+        context.insert(cycle)
+        try context.save()
+
+        context.delete(playbook)
+        try context.save()
+
+        let cycleDescriptor = FetchDescriptor<WeeklyCycleModel>()
+        let remainingCycles = try context.fetch(cycleDescriptor)
+        #expect(remainingCycles.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- Add SwiftData `@Model` classes: `PlaybookModel`, `TaskModel`, `SectionModel`, `WeeklyCycleModel` with relationships and cascade delete rules
- Add domain enums (`PlaybookPhase`, `TaskLane`, `TaskStatus`, `SectionType`) with `Codable`, `Hashable`, `CaseIterable` conformances and raw values matching the backend API contract
- Add `UserSession` struct (Keychain-bound, not SwiftData) for auth token storage
- Register `ModelContainer` in app entry point — SwiftData auto-discovers related models via relationships
- Replace temporary inner enums in `PhaseBadge` and `LaneChip` with canonical domain enums
- Enums stored as raw `String` values via computed properties for SwiftData compatibility

## Test plan
- [x] All `@Model` classes compile with SwiftData
- [x] Enums are `Codable`, `Hashable`, `CaseIterable`
- [x] `ModelContainer` registered in app entry point
- [x] Relationships defined (Playbook → Tasks, Playbook → Sections, Playbook → WeeklyCycles)
- [x] No force unwrapping
- [x] Unit tests: CRUD each model in in-memory container (28 tests)
- [x] Enum coding roundtrip tests
- [x] Cascade delete tests (Playbook deletion removes Tasks, Sections, WeeklyCycles)
- [x] Relationship bidirectional tests
- [x] `PhaseBadge` and `LaneChip` previews render with domain enums

🤖 Generated with [Claude Code](https://claude.com/claude-code)