### PR TITLE
feat(networking): APIClient with typed requests, auth injection, 401 refresh

### DIFF
--- a/idea-pilot/idea-pilot/Core/Networking/APIClient.swift
+++ b/idea-pilot/idea-pilot/Core/Networking/APIClient.swift
@@ -1,0 +1,222 @@
+//
+//  APIClient.swift
+//  idea-pilot
+//
+//  Centralized networking layer for all API communication.
+//
+
+import Foundation
+
+/// The centralized networking layer for all Idea Pilot API calls.
+///
+/// All requests flow through `APIClient`, which handles:
+/// - Typed JSON encoding/decoding
+/// - Bearer token injection via `TokenProviding`
+/// - Transparent 401 refresh-and-retry (once)
+/// - Error mapping to `APIError`
+/// - Debug-only request/response logging
+///
+/// Usage:
+/// ```swift
+/// let client = APIClient(baseURL: url, session: .shared, tokenProvider: tokenManager)
+/// let playbooks: [PlaybookDTO] = try await client.request(.getPlaybooks())
+/// ```
+final class APIClient: Sendable {
+
+    private let baseURL: URL
+    private let session: URLSession
+    private let tokenProvider: (any TokenProviding)?
+    private let decoder: JSONDecoder
+    private let encoder: JSONEncoder
+
+    /// Creates an API client.
+    ///
+    /// - Parameters:
+    ///   - baseURL: The root URL of the API (e.g., `https://api.ideapilot.app`).
+    ///   - session: The `URLSession` to use. Injectable for testing.
+    ///   - tokenProvider: Provides access tokens and refresh capability. Pass `nil` for unauthenticated clients.
+    init(baseURL: URL, session: URLSession = .shared, tokenProvider: (any TokenProviding)? = nil) {
+        self.baseURL = baseURL
+        self.session = session
+        self.tokenProvider = tokenProvider
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .iso8601
+        self.decoder = decoder
+
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        encoder.dateEncodingStrategy = .iso8601
+        self.encoder = encoder
+    }
+
+    /// Sends a request and decodes the response into the given type.
+    ///
+    /// - Parameter endpoint: The API endpoint to call.
+    /// - Returns: The decoded response.
+    /// - Throws: `APIError` on failure.
+    func request<T: Decodable & Sendable>(_ endpoint: Endpoint) async throws -> T {
+        let urlRequest = try await buildURLRequest(for: endpoint)
+        return try await execute(request: urlRequest, endpoint: endpoint, isRetry: false)
+    }
+
+    /// Sends a request that returns no response body (e.g., DELETE, 204).
+    ///
+    /// - Parameter endpoint: The API endpoint to call.
+    /// - Throws: `APIError` on failure.
+    func requestVoid(_ endpoint: Endpoint) async throws {
+        let urlRequest = try await buildURLRequest(for: endpoint)
+        let (data, response) = try await performRequest(urlRequest)
+        let statusCode = response.statusCode
+
+        if statusCode == 401 && endpoint.requiresAuth {
+            try await handleUnauthorized(endpoint: endpoint)
+            return
+        }
+
+        try mapErrorStatus(statusCode, data: data)
+    }
+
+    // MARK: - Private
+
+    private func buildURLRequest(for endpoint: Endpoint) async throws -> URLRequest {
+        var components = URLComponents(url: baseURL.appendingPathComponent(endpoint.path), resolvingAgainstBaseURL: true)
+        components?.queryItems = endpoint.queryItems
+
+        guard let url = components?.url else {
+            throw APIError.badRequest("Invalid URL for path: \(endpoint.path)")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = endpoint.method.rawValue
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        if let body = endpoint.body {
+            request.httpBody = try encoder.encode(body)
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+
+        if endpoint.requiresAuth, let token = await tokenProvider?.accessToken {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        return request
+    }
+
+    private func execute<T: Decodable & Sendable>(
+        request: URLRequest,
+        endpoint: Endpoint,
+        isRetry: Bool
+    ) async throws -> T {
+        let (data, response) = try await performRequest(request)
+        let statusCode = response.statusCode
+
+        #if DEBUG
+        logRequest(request, statusCode: statusCode, data: data)
+        #endif
+
+        if statusCode == 401 && !isRetry && endpoint.requiresAuth {
+            return try await handleUnauthorized(endpoint: endpoint)
+        }
+
+        try mapErrorStatus(statusCode, data: data)
+
+        do {
+            return try decoder.decode(T.self, from: data)
+        } catch let error as DecodingError {
+            throw APIError.decodingError(error.localizedDescription)
+        }
+    }
+
+    private func handleUnauthorized<T: Decodable & Sendable>(endpoint: Endpoint) async throws -> T {
+        guard let provider = tokenProvider else {
+            throw APIError.sessionExpired
+        }
+
+        do {
+            try await provider.refresh()
+        } catch {
+            await provider.clearTokens()
+            throw APIError.sessionExpired
+        }
+
+        let retryRequest = try await buildURLRequest(for: endpoint)
+        return try await execute(request: retryRequest, endpoint: endpoint, isRetry: true)
+    }
+
+    private func handleUnauthorized(endpoint: Endpoint) async throws {
+        guard let provider = tokenProvider else {
+            throw APIError.sessionExpired
+        }
+
+        do {
+            try await provider.refresh()
+        } catch {
+            await provider.clearTokens()
+            throw APIError.sessionExpired
+        }
+
+        let retryRequest = try await buildURLRequest(for: endpoint)
+        let (data, response) = try await performRequest(retryRequest)
+        try mapErrorStatus(response.statusCode, data: data)
+    }
+
+    private func performRequest(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        let data: Data
+        let response: URLResponse
+
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch let urlError as URLError {
+            if urlError.code == .notConnectedToInternet {
+                throw APIError.offline
+            }
+            throw APIError.networkError(urlError)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.networkError(URLError(.badServerResponse))
+        }
+
+        return (data, httpResponse)
+    }
+
+    private func mapErrorStatus(_ statusCode: Int, data: Data) throws {
+        switch statusCode {
+        case 200...299:
+            return
+        case 400:
+            let message = extractErrorMessage(from: data)
+            throw APIError.badRequest(message)
+        case 401:
+            throw APIError.sessionExpired
+        case 404:
+            throw APIError.notFound
+        case 500...599:
+            let message = extractErrorMessage(from: data)
+            throw APIError.serverError(statusCode, message)
+        default:
+            let message = extractErrorMessage(from: data)
+            throw APIError.serverError(statusCode, message)
+        }
+    }
+
+    private func extractErrorMessage(from data: Data) -> String? {
+        struct ErrorBody: Decodable { let message: String? }
+        return try? JSONDecoder().decode(ErrorBody.self, from: data).message
+    }
+
+    #if DEBUG
+    private func logRequest(_ request: URLRequest, statusCode: Int, data: Data) {
+        let method = request.httpMethod ?? "?"
+        let url = request.url?.absoluteString ?? "?"
+        let bodyPreview = data.prefix(500)
+        let bodyString = String(data: bodyPreview, encoding: .utf8) ?? "<binary>"
+        print("[\(method)] \(url) → \(statusCode) (\(data.count) bytes)")
+        if data.count > 0 {
+            print("  Response: \(bodyString)")
+        }
+    }
+    #endif
+}

--- a/idea-pilot/idea-pilot/Core/Networking/APIError.swift
+++ b/idea-pilot/idea-pilot/Core/Networking/APIError.swift
@@ -1,0 +1,37 @@
+//
+//  APIError.swift
+//  idea-pilot
+//
+//  Error types for the API networking layer.
+//
+
+import Foundation
+
+/// Errors emitted by `APIClient`.
+///
+/// These cover the full range of failure modes: auth, network, decoding,
+/// and server-side errors. UI layers can switch on these to display
+/// appropriate feedback (inline banners, toasts, redirects).
+nonisolated enum APIError: Error, Equatable, Sendable {
+
+    /// The server returned 401 and the token refresh also failed.
+    case sessionExpired
+
+    /// The server returned 400 with an optional validation message.
+    case badRequest(String?)
+
+    /// The server returned 404.
+    case notFound
+
+    /// The server returned an unexpected status code (e.g., 500).
+    case serverError(Int, String?)
+
+    /// A network-level failure (timeout, DNS, TLS, etc.).
+    case networkError(URLError)
+
+    /// The response body could not be decoded into the expected type.
+    case decodingError(String)
+
+    /// The device has no internet connection.
+    case offline
+}

--- a/idea-pilot/idea-pilot/Core/Networking/DTOs/AuthDTO.swift
+++ b/idea-pilot/idea-pilot/Core/Networking/DTOs/AuthDTO.swift
@@ -1,0 +1,42 @@
+//
+//  AuthDTO.swift
+//  idea-pilot
+//
+//  Data transfer objects for authentication endpoints.
+//
+
+import Foundation
+
+/// Request body for `POST /v1/auth/login`.
+nonisolated struct LoginRequestDTO: Codable, Sendable {
+    let email: String
+    let password: String
+}
+
+/// Response from login and token refresh endpoints.
+nonisolated struct AuthTokensDTO: Codable, Sendable {
+    let accessToken: String
+    let refreshToken: String
+    let userId: String
+    let email: String
+}
+
+/// Request body for `POST /v1/auth/refresh`.
+nonisolated struct RefreshTokenRequestDTO: Codable, Sendable {
+    let refreshToken: String
+}
+
+// MARK: - Mapping
+
+extension AuthTokensDTO {
+
+    /// Converts the auth response into a `UserSession` for Keychain storage.
+    func toUserSession() -> UserSession {
+        UserSession(
+            userId: userId,
+            email: email,
+            accessToken: accessToken,
+            refreshToken: refreshToken
+        )
+    }
+}

--- a/idea-pilot/idea-pilot/Core/Networking/DTOs/PlaybookDTO.swift
+++ b/idea-pilot/idea-pilot/Core/Networking/DTOs/PlaybookDTO.swift
@@ -1,0 +1,77 @@
+//
+//  PlaybookDTO.swift
+//  idea-pilot
+//
+//  Data transfer objects for Playbook API endpoints.
+//
+
+import Foundation
+
+/// Response DTO for a Playbook from the API.
+nonisolated struct PlaybookDTO: Codable, Sendable {
+    let id: String
+    let title: String
+    let description: String?
+    let phase: String
+    let isArchived: Bool
+    let createdAt: Date
+    let updatedAt: Date
+    let tasks: [TaskDTO]?
+    let sections: [SectionDTO]?
+}
+
+/// Request body for `POST /v1/playbooks`.
+nonisolated struct CreatePlaybookDTO: Codable, Sendable {
+    let title: String
+    let description: String?
+    let phase: String
+}
+
+/// Request body for `PATCH /v1/playbooks/:id`.
+nonisolated struct UpdatePlaybookDTO: Codable, Sendable {
+    let title: String?
+    let description: String?
+    let phase: String?
+    let isArchived: Bool?
+}
+
+// MARK: - Mapping
+
+extension PlaybookDTO {
+
+    /// Converts the DTO into a SwiftData model.
+    @MainActor
+    func toModel() -> PlaybookModel {
+        PlaybookModel(
+            id: id,
+            title: title,
+            descriptionText: description,
+            phase: PlaybookPhase(rawValue: phase) ?? .proof,
+            isArchived: isArchived,
+            createdAt: createdAt,
+            updatedAt: updatedAt
+        )
+    }
+}
+
+extension PlaybookModel {
+
+    /// Creates a DTO for creating a new playbook on the server.
+    func toCreateDTO() -> CreatePlaybookDTO {
+        CreatePlaybookDTO(
+            title: title,
+            description: descriptionText,
+            phase: phase.rawValue
+        )
+    }
+
+    /// Creates a DTO for updating an existing playbook on the server.
+    func toUpdateDTO() -> UpdatePlaybookDTO {
+        UpdatePlaybookDTO(
+            title: title,
+            description: descriptionText,
+            phase: phase.rawValue,
+            isArchived: isArchived
+        )
+    }
+}

--- a/idea-pilot/idea-pilot/Core/Networking/DTOs/SectionDTO.swift
+++ b/idea-pilot/idea-pilot/Core/Networking/DTOs/SectionDTO.swift
@@ -1,0 +1,45 @@
+//
+//  SectionDTO.swift
+//  idea-pilot
+//
+//  Data transfer objects for Section API endpoints.
+//
+
+import Foundation
+
+/// Response DTO for a Section from the API.
+nonisolated struct SectionDTO: Codable, Sendable {
+    let playbookId: String
+    let sectionType: String
+    let content: String
+    let updatedAt: Date
+}
+
+/// Request body for `PUT /v1/playbooks/:id/sections/:type`.
+nonisolated struct UpdateSectionDTO: Codable, Sendable {
+    let content: String
+}
+
+// MARK: - Mapping
+
+extension SectionDTO {
+
+    /// Converts the DTO into a SwiftData model.
+    @MainActor
+    func toModel() -> SectionModel {
+        SectionModel(
+            playbookId: playbookId,
+            sectionType: SectionType(rawValue: sectionType) ?? .vision,
+            content: content,
+            updatedAt: updatedAt
+        )
+    }
+}
+
+extension SectionModel {
+
+    /// Creates a DTO for updating this section on the server.
+    func toUpdateDTO() -> UpdateSectionDTO {
+        UpdateSectionDTO(content: content)
+    }
+}

--- a/idea-pilot/idea-pilot/Core/Networking/DTOs/TaskDTO.swift
+++ b/idea-pilot/idea-pilot/Core/Networking/DTOs/TaskDTO.swift
@@ -1,0 +1,98 @@
+//
+//  TaskDTO.swift
+//  idea-pilot
+//
+//  Data transfer objects for Task API endpoints.
+//
+
+import Foundation
+
+/// Response DTO for a Task from the API.
+nonisolated struct TaskDTO: Codable, Sendable {
+    let id: String
+    let playbookId: String
+    let title: String
+    let detail: String?
+    let lane: String
+    let estimatedMinutes: Int
+    let status: String
+    let orderIndex: Int
+    let completedAt: Date?
+    let createdAt: Date
+    let updatedAt: Date
+}
+
+/// Request body for `POST /v1/tasks`.
+nonisolated struct CreateTaskDTO: Codable, Sendable {
+    let playbookId: String
+    let title: String
+    let detail: String?
+    let lane: String
+    let estimatedMinutes: Int
+}
+
+/// Request body for `PATCH /v1/tasks/:id`.
+nonisolated struct UpdateTaskDTO: Codable, Sendable {
+    let title: String?
+    let detail: String?
+    let lane: String?
+    let estimatedMinutes: Int?
+    let status: String?
+    let orderIndex: Int?
+}
+
+/// Request body for `POST /v1/tasks/reorder`.
+nonisolated struct ReorderTasksDTO: Codable, Sendable {
+    let playbookId: String
+    let lane: String
+    let taskIds: [String]
+}
+
+// MARK: - Mapping
+
+extension TaskDTO {
+
+    /// Converts the DTO into a SwiftData model.
+    @MainActor
+    func toModel() -> TaskModel {
+        TaskModel(
+            id: id,
+            playbookId: playbookId,
+            title: title,
+            detail: detail,
+            lane: TaskLane(rawValue: lane) ?? .later,
+            estimatedMinutes: estimatedMinutes,
+            status: TaskStatus(rawValue: status) ?? .open,
+            orderIndex: orderIndex,
+            completedAt: completedAt,
+            createdAt: createdAt,
+            updatedAt: updatedAt
+        )
+    }
+}
+
+extension TaskModel {
+
+    /// Creates a DTO for creating a new task on the server.
+    func toCreateDTO() -> CreateTaskDTO {
+        CreateTaskDTO(
+            playbookId: playbookId,
+            title: title,
+            detail: detail,
+            lane: lane.rawValue,
+            estimatedMinutes: estimatedMinutes
+        )
+    }
+
+    /// Creates a DTO for updating an existing task on the server.
+    func toUpdateDTO() -> UpdateTaskDTO {
+        UpdateTaskDTO(
+            title: title,
+            detail: detail,
+            lane: lane.rawValue,
+            estimatedMinutes: estimatedMinutes,
+            status: status.rawValue,
+            orderIndex: orderIndex
+        )
+    }
+}

--- a/idea-pilot/idea-pilot/Core/Networking/DTOs/WeeklyCycleDTO.swift
+++ b/idea-pilot/idea-pilot/Core/Networking/DTOs/WeeklyCycleDTO.swift
@@ -1,0 +1,38 @@
+//
+//  WeeklyCycleDTO.swift
+//  idea-pilot
+//
+//  Data transfer objects for WeeklyCycle API endpoints.
+//
+
+import Foundation
+
+/// Response DTO for a WeeklyCycle from the API.
+nonisolated struct WeeklyCycleDTO: Codable, Sendable {
+    let id: String
+    let playbookId: String
+    let weekStartDate: Date
+    let completedCount: Int
+    let totalCount: Int
+    let createdAt: Date
+    let updatedAt: Date
+}
+
+// MARK: - Mapping
+
+extension WeeklyCycleDTO {
+
+    /// Converts the DTO into a SwiftData model.
+    @MainActor
+    func toModel() -> WeeklyCycleModel {
+        WeeklyCycleModel(
+            id: id,
+            playbookId: playbookId,
+            weekStartDate: weekStartDate,
+            completedCount: completedCount,
+            totalCount: totalCount,
+            createdAt: createdAt,
+            updatedAt: updatedAt
+        )
+    }
+}

--- a/idea-pilot/idea-pilot/Core/Networking/Endpoint.swift
+++ b/idea-pilot/idea-pilot/Core/Networking/Endpoint.swift
@@ -1,0 +1,134 @@
+//
+//  Endpoint.swift
+//  idea-pilot
+//
+//  Typed API endpoint definitions with static factory methods.
+//
+
+import Foundation
+
+/// A type-safe description of an API request.
+///
+/// Endpoints are value types that describe *what* to request — the path, HTTP method,
+/// body, and query parameters. `APIClient` uses these to build `URLRequest` objects.
+///
+/// Use the static factory methods instead of constructing directly:
+/// ```swift
+/// let playbooks: [PlaybookDTO] = try await client.request(.getPlaybooks())
+/// ```
+nonisolated struct Endpoint: Sendable {
+
+    /// The URL path relative to the base URL (e.g., `"/v1/playbooks"`).
+    let path: String
+
+    /// The HTTP method.
+    let method: HTTPMethod
+
+    /// The JSON-encodable request body, or `nil` for bodyless requests.
+    let body: (any Encodable & Sendable)?
+
+    /// Optional query parameters.
+    let queryItems: [URLQueryItem]?
+
+    /// Whether this endpoint requires authentication (default: `true`).
+    let requiresAuth: Bool
+
+    init(
+        path: String,
+        method: HTTPMethod,
+        body: (any Encodable & Sendable)? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        requiresAuth: Bool = true
+    ) {
+        self.path = path
+        self.method = method
+        self.body = body
+        self.queryItems = queryItems
+        self.requiresAuth = requiresAuth
+    }
+}
+
+// MARK: - Auth Endpoints
+
+extension Endpoint {
+
+    static func login(dto: LoginRequestDTO) -> Endpoint {
+        Endpoint(path: "/v1/auth/login", method: .post, body: dto, requiresAuth: false)
+    }
+
+    static func refreshToken(dto: RefreshTokenRequestDTO) -> Endpoint {
+        Endpoint(path: "/v1/auth/refresh", method: .post, body: dto, requiresAuth: false)
+    }
+}
+
+// MARK: - Playbook Endpoints
+
+extension Endpoint {
+
+    static func getPlaybooks() -> Endpoint {
+        Endpoint(path: "/v1/playbooks", method: .get)
+    }
+
+    static func getPlaybook(id: String) -> Endpoint {
+        Endpoint(path: "/v1/playbooks/\(id)", method: .get)
+    }
+
+    static func createPlaybook(dto: CreatePlaybookDTO) -> Endpoint {
+        Endpoint(path: "/v1/playbooks", method: .post, body: dto)
+    }
+
+    static func updatePlaybook(id: String, dto: UpdatePlaybookDTO) -> Endpoint {
+        Endpoint(path: "/v1/playbooks/\(id)", method: .patch, body: dto)
+    }
+
+    static func deletePlaybook(id: String) -> Endpoint {
+        Endpoint(path: "/v1/playbooks/\(id)", method: .delete)
+    }
+}
+
+// MARK: - Task Endpoints
+
+extension Endpoint {
+
+    static func getTasks(playbookId: String) -> Endpoint {
+        Endpoint(path: "/v1/playbooks/\(playbookId)/tasks", method: .get)
+    }
+
+    static func createTask(dto: CreateTaskDTO) -> Endpoint {
+        Endpoint(path: "/v1/tasks", method: .post, body: dto)
+    }
+
+    static func updateTask(id: String, dto: UpdateTaskDTO) -> Endpoint {
+        Endpoint(path: "/v1/tasks/\(id)", method: .patch, body: dto)
+    }
+
+    static func deleteTask(id: String) -> Endpoint {
+        Endpoint(path: "/v1/tasks/\(id)", method: .delete)
+    }
+
+    static func reorderTasks(dto: ReorderTasksDTO) -> Endpoint {
+        Endpoint(path: "/v1/tasks/reorder", method: .post, body: dto)
+    }
+}
+
+// MARK: - Section Endpoints
+
+extension Endpoint {
+
+    static func getSections(playbookId: String) -> Endpoint {
+        Endpoint(path: "/v1/playbooks/\(playbookId)/sections", method: .get)
+    }
+
+    static func updateSection(playbookId: String, sectionType: String, dto: UpdateSectionDTO) -> Endpoint {
+        Endpoint(path: "/v1/playbooks/\(playbookId)/sections/\(sectionType)", method: .put, body: dto)
+    }
+}
+
+// MARK: - Weekly Cycle Endpoints
+
+extension Endpoint {
+
+    static func getWeeklyCycles(playbookId: String) -> Endpoint {
+        Endpoint(path: "/v1/playbooks/\(playbookId)/weekly-cycles", method: .get)
+    }
+}

--- a/idea-pilot/idea-pilot/Core/Networking/HTTPMethod.swift
+++ b/idea-pilot/idea-pilot/Core/Networking/HTTPMethod.swift
@@ -1,0 +1,17 @@
+//
+//  HTTPMethod.swift
+//  idea-pilot
+//
+//  HTTP methods supported by the API client.
+//
+
+import Foundation
+
+/// HTTP methods used by the Idea Pilot API.
+nonisolated enum HTTPMethod: String, Sendable {
+    case get = "GET"
+    case post = "POST"
+    case patch = "PATCH"
+    case put = "PUT"
+    case delete = "DELETE"
+}

--- a/idea-pilot/idea-pilot/Core/Networking/TokenProviding.swift
+++ b/idea-pilot/idea-pilot/Core/Networking/TokenProviding.swift
@@ -1,0 +1,30 @@
+//
+//  TokenProviding.swift
+//  idea-pilot
+//
+//  Protocol for token access and refresh.
+//  Concrete implementation: TokenManager (Issue #7).
+//
+
+import Foundation
+
+/// Provides access tokens and refresh capability to `APIClient`.
+///
+/// `APIClient` uses this protocol to inject Bearer tokens into requests
+/// and to transparently refresh expired tokens on 401 responses.
+///
+/// The concrete implementation (`TokenManager`, Issue #7) will handle
+/// Keychain storage and the refresh endpoint call.
+protocol TokenProviding: Sendable {
+
+    /// The current access token, or `nil` if the user is not authenticated.
+    var accessToken: String? { get async }
+
+    /// Attempts to refresh the access token using the stored refresh token.
+    ///
+    /// - Throws: If the refresh token is invalid or the refresh request fails.
+    func refresh() async throws
+
+    /// Clears all stored tokens (sign-out).
+    func clearTokens() async
+}

--- a/idea-pilot/idea-pilotTests/APIClientTests.swift
+++ b/idea-pilot/idea-pilotTests/APIClientTests.swift
@@ -1,0 +1,493 @@
+//
+//  APIClientTests.swift
+//  idea-pilotTests
+//
+//  Unit tests for APIClient, Endpoint, DTOs, and error handling.
+//
+
+import Foundation
+import Testing
+@testable import idea_pilot
+
+// MARK: - Mock URL Protocol
+
+/// A `URLProtocol` subclass that intercepts network requests for testing.
+final class MockURLProtocol: URLProtocol, @unchecked Sendable {
+
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> (Data, HTTPURLResponse))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = MockURLProtocol.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+
+        do {
+            let (data, response) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Mock Token Provider
+
+/// A mock `TokenProviding` implementation for testing auth behavior.
+final class MockTokenProvider: TokenProviding, @unchecked Sendable {
+    nonisolated(unsafe) var _accessToken: String?
+    nonisolated(unsafe) var refreshCalled = false
+    nonisolated(unsafe) var refreshShouldFail = false
+    nonisolated(unsafe) var newTokenAfterRefresh: String?
+    nonisolated(unsafe) var clearCalled = false
+
+    nonisolated var accessToken: String? {
+        get async { _accessToken }
+    }
+
+    nonisolated func refresh() async throws {
+        refreshCalled = true
+        if refreshShouldFail {
+            throw APIError.sessionExpired
+        }
+        if let newToken = newTokenAfterRefresh {
+            _accessToken = newToken
+        }
+    }
+
+    nonisolated func clearTokens() async {
+        clearCalled = true
+        _accessToken = nil
+    }
+}
+
+// MARK: - Test Helpers
+
+private let testBaseURL = URL(string: "https://api.test.ideapilot.app")!
+
+private func makeTestSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+private nonisolated func makeResponse(statusCode: Int) -> HTTPURLResponse {
+    HTTPURLResponse(
+        url: testBaseURL,
+        statusCode: statusCode,
+        httpVersion: nil,
+        headerFields: nil
+    )!
+}
+
+/// A simple Codable struct for test responses.
+nonisolated struct TestItem: Codable, Sendable, Equatable {
+    let id: String
+    let name: String
+}
+
+// MARK: - APIClient Tests
+
+@Suite("APIClient", .serialized)
+struct APIClientTests {
+
+    @Test("successful GET decodes typed response")
+    func successfulGet() async throws {
+        let json = #"[{"id":"1","name":"Test"}]"#
+        MockURLProtocol.handler = { _ in
+            (Data(json.utf8), makeResponse(statusCode: 200))
+        }
+
+        let client = APIClient(baseURL: testBaseURL, session: makeTestSession())
+        let items: [TestItem] = try await client.request(
+            Endpoint(path: "/v1/test", method: .get, requiresAuth: false)
+        )
+
+        #expect(items == [TestItem(id: "1", name: "Test")])
+        MockURLProtocol.handler = nil
+    }
+
+    @Test("successful POST sends body and decodes response")
+    func successfulPost() async throws {
+        let responseJSON = #"{"id":"new-1","name":"Created"}"#
+        nonisolated(unsafe) var capturedMethod: String?
+        nonisolated(unsafe) var capturedContentType: String?
+
+        MockURLProtocol.handler = { request in
+            capturedMethod = request.httpMethod
+            capturedContentType = request.value(forHTTPHeaderField: "Content-Type")
+            return (Data(responseJSON.utf8), makeResponse(statusCode: 201))
+        }
+
+        let client = APIClient(baseURL: testBaseURL, session: makeTestSession())
+        let item: TestItem = try await client.request(
+            Endpoint(
+                path: "/v1/test",
+                method: .post,
+                body: TestItem(id: "new-1", name: "Created"),
+                requiresAuth: false
+            )
+        )
+
+        #expect(item.id == "new-1")
+        #expect(capturedMethod == "POST")
+        #expect(capturedContentType == "application/json")
+        MockURLProtocol.handler = nil
+    }
+
+    @Test("Bearer token injected in Authorization header")
+    func bearerTokenInjected() async throws {
+        let json = #"{"id":"1","name":"Test"}"#
+        nonisolated(unsafe) var capturedAuth: String?
+
+        MockURLProtocol.handler = { request in
+            capturedAuth = request.value(forHTTPHeaderField: "Authorization")
+            return (Data(json.utf8), makeResponse(statusCode: 200))
+        }
+
+        let tokenProvider = MockTokenProvider()
+        tokenProvider._accessToken = "test-token-123"
+
+        let client = APIClient(baseURL: testBaseURL, session: makeTestSession(), tokenProvider: tokenProvider)
+        let _: TestItem = try await client.request(
+            Endpoint(path: "/v1/test", method: .get)
+        )
+
+        #expect(capturedAuth == "Bearer test-token-123")
+        MockURLProtocol.handler = nil
+    }
+
+    @Test("no auth header when tokenProvider is nil")
+    func noAuthHeaderWithoutProvider() async throws {
+        let json = #"{"id":"1","name":"Test"}"#
+        nonisolated(unsafe) var capturedAuth: String?
+
+        MockURLProtocol.handler = { request in
+            capturedAuth = request.value(forHTTPHeaderField: "Authorization")
+            return (Data(json.utf8), makeResponse(statusCode: 200))
+        }
+
+        let client = APIClient(baseURL: testBaseURL, session: makeTestSession())
+        let _: TestItem = try await client.request(
+            Endpoint(path: "/v1/test", method: .get)
+        )
+
+        #expect(capturedAuth == nil)
+        MockURLProtocol.handler = nil
+    }
+
+    @Test("401 triggers refresh and retry")
+    func refreshAndRetry() async throws {
+        let successJSON = #"{"id":"1","name":"Refreshed"}"#
+        nonisolated(unsafe) var callCount = 0
+
+        MockURLProtocol.handler = { _ in
+            callCount += 1
+            if callCount == 1 {
+                return (Data(), makeResponse(statusCode: 401))
+            }
+            return (Data(successJSON.utf8), makeResponse(statusCode: 200))
+        }
+
+        let tokenProvider = MockTokenProvider()
+        tokenProvider._accessToken = "expired-token"
+        tokenProvider.newTokenAfterRefresh = "fresh-token"
+
+        let client = APIClient(baseURL: testBaseURL, session: makeTestSession(), tokenProvider: tokenProvider)
+        let item: TestItem = try await client.request(
+            Endpoint(path: "/v1/test", method: .get)
+        )
+
+        #expect(item.name == "Refreshed")
+        #expect(tokenProvider.refreshCalled)
+        #expect(callCount == 2)
+        MockURLProtocol.handler = nil
+    }
+
+    @Test("401 with failed refresh throws sessionExpired")
+    func failedRefreshThrowsSessionExpired() async throws {
+        MockURLProtocol.handler = { _ in
+            (Data(), makeResponse(statusCode: 401))
+        }
+
+        let tokenProvider = MockTokenProvider()
+        tokenProvider._accessToken = "expired-token"
+        tokenProvider.refreshShouldFail = true
+
+        let client = APIClient(baseURL: testBaseURL, session: makeTestSession(), tokenProvider: tokenProvider)
+
+        await #expect(throws: APIError.sessionExpired) {
+            let _: TestItem = try await client.request(
+                Endpoint(path: "/v1/test", method: .get)
+            )
+        }
+
+        #expect(tokenProvider.clearCalled)
+        MockURLProtocol.handler = nil
+    }
+
+    @Test("404 mapped to notFound")
+    func notFound() async throws {
+        MockURLProtocol.handler = { _ in
+            (Data(), makeResponse(statusCode: 404))
+        }
+
+        let client = APIClient(baseURL: testBaseURL, session: makeTestSession())
+
+        await #expect(throws: APIError.notFound) {
+            let _: TestItem = try await client.request(
+                Endpoint(path: "/v1/test", method: .get, requiresAuth: false)
+            )
+        }
+        MockURLProtocol.handler = nil
+    }
+
+    @Test("500 mapped to serverError")
+    func serverError() async throws {
+        let errorJSON = #"{"message":"Internal server error"}"#
+        MockURLProtocol.handler = { _ in
+            (Data(errorJSON.utf8), makeResponse(statusCode: 500))
+        }
+
+        let client = APIClient(baseURL: testBaseURL, session: makeTestSession())
+
+        await #expect(throws: APIError.serverError(500, "Internal server error")) {
+            let _: TestItem = try await client.request(
+                Endpoint(path: "/v1/test", method: .get, requiresAuth: false)
+            )
+        }
+        MockURLProtocol.handler = nil
+    }
+
+    @Test("400 mapped to badRequest")
+    func badRequest() async throws {
+        let errorJSON = #"{"message":"Title is required"}"#
+        MockURLProtocol.handler = { _ in
+            (Data(errorJSON.utf8), makeResponse(statusCode: 400))
+        }
+
+        let client = APIClient(baseURL: testBaseURL, session: makeTestSession())
+
+        await #expect(throws: APIError.badRequest("Title is required")) {
+            let _: TestItem = try await client.request(
+                Endpoint(path: "/v1/test", method: .get, requiresAuth: false)
+            )
+        }
+        MockURLProtocol.handler = nil
+    }
+
+    @Test("decoding error mapped correctly")
+    func decodingError() async throws {
+        let invalidJSON = #"{"wrong_field":"value"}"#
+        MockURLProtocol.handler = { _ in
+            (Data(invalidJSON.utf8), makeResponse(statusCode: 200))
+        }
+
+        let client = APIClient(baseURL: testBaseURL, session: makeTestSession())
+
+        do {
+            let _: TestItem = try await client.request(
+                Endpoint(path: "/v1/test", method: .get, requiresAuth: false)
+            )
+            Issue.record("Expected decodingError")
+        } catch let error as APIError {
+            guard case .decodingError = error else {
+                Issue.record("Expected decodingError, got \(error)")
+                return
+            }
+        }
+        MockURLProtocol.handler = nil
+    }
+
+    @Test("network error when offline")
+    func offlineError() async throws {
+        MockURLProtocol.handler = { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+
+        let client = APIClient(baseURL: testBaseURL, session: makeTestSession())
+
+        await #expect(throws: APIError.offline) {
+            let _: TestItem = try await client.request(
+                Endpoint(path: "/v1/test", method: .get, requiresAuth: false)
+            )
+        }
+        MockURLProtocol.handler = nil
+    }
+
+    @Test("requestVoid succeeds on 204")
+    func requestVoidSuccess() async throws {
+        MockURLProtocol.handler = { _ in
+            (Data(), makeResponse(statusCode: 204))
+        }
+
+        let client = APIClient(baseURL: testBaseURL, session: makeTestSession())
+        try await client.requestVoid(
+            Endpoint(path: "/v1/test/1", method: .delete, requiresAuth: false)
+        )
+        MockURLProtocol.handler = nil
+    }
+}
+
+// MARK: - Endpoint Tests
+
+@Suite("Endpoint")
+struct EndpointTests {
+
+    @Test("auth endpoints do not require auth")
+    func authEndpointsNoAuth() {
+        let login = Endpoint.login(dto: LoginRequestDTO(email: "a@b.com", password: "pass"))
+        #expect(login.requiresAuth == false)
+
+        let refresh = Endpoint.refreshToken(dto: RefreshTokenRequestDTO(refreshToken: "tok"))
+        #expect(refresh.requiresAuth == false)
+    }
+
+    @Test("playbook endpoints use correct paths and methods")
+    func playbookEndpoints() {
+        let list = Endpoint.getPlaybooks()
+        #expect(list.path == "/v1/playbooks")
+        #expect(list.method == .get)
+
+        let detail = Endpoint.getPlaybook(id: "abc")
+        #expect(detail.path == "/v1/playbooks/abc")
+
+        let delete = Endpoint.deletePlaybook(id: "xyz")
+        #expect(delete.method == .delete)
+    }
+
+    @Test("task endpoints use correct paths")
+    func taskEndpoints() {
+        let tasks = Endpoint.getTasks(playbookId: "pb-1")
+        #expect(tasks.path == "/v1/playbooks/pb-1/tasks")
+
+        let delete = Endpoint.deleteTask(id: "t-1")
+        #expect(delete.path == "/v1/tasks/t-1")
+        #expect(delete.method == .delete)
+    }
+}
+
+// MARK: - DTO Tests
+
+@Suite("DTOs")
+struct DTOTests {
+
+    @Test("AuthTokensDTO maps to UserSession")
+    func authTokensMapping() {
+        let dto = AuthTokensDTO(
+            accessToken: "access",
+            refreshToken: "refresh",
+            userId: "user-1",
+            email: "test@example.com"
+        )
+        let session = dto.toUserSession()
+        #expect(session.userId == "user-1")
+        #expect(session.email == "test@example.com")
+        #expect(session.accessToken == "access")
+        #expect(session.refreshToken == "refresh")
+    }
+
+    @Test("PlaybookDTO Codable roundtrip with snake_case")
+    func playbookDTOCodable() throws {
+        let json = """
+        {
+            "id": "pb-1",
+            "title": "My Playbook",
+            "description": null,
+            "phase": "PROOF",
+            "is_archived": false,
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "tasks": null,
+            "sections": null
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .iso8601
+
+        let dto = try decoder.decode(PlaybookDTO.self, from: Data(json.utf8))
+        #expect(dto.id == "pb-1")
+        #expect(dto.title == "My Playbook")
+        #expect(dto.phase == "PROOF")
+        #expect(dto.isArchived == false)
+    }
+
+    @Test("TaskDTO Codable roundtrip with snake_case")
+    func taskDTOCodable() throws {
+        let json = """
+        {
+            "id": "t-1",
+            "playbook_id": "pb-1",
+            "title": "Write tests",
+            "detail": null,
+            "lane": "NOW",
+            "estimated_minutes": 90,
+            "status": "OPEN",
+            "order_index": 0,
+            "completed_at": null,
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z"
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .iso8601
+
+        let dto = try decoder.decode(TaskDTO.self, from: Data(json.utf8))
+        #expect(dto.id == "t-1")
+        #expect(dto.playbookId == "pb-1")
+        #expect(dto.lane == "NOW")
+        #expect(dto.estimatedMinutes == 90)
+    }
+
+    @Test("SectionDTO Codable roundtrip with snake_case")
+    func sectionDTOCodable() throws {
+        let json = """
+        {
+            "playbook_id": "pb-1",
+            "section_type": "VISION",
+            "content": "Build something great",
+            "updated_at": "2026-01-01T00:00:00Z"
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .iso8601
+
+        let dto = try decoder.decode(SectionDTO.self, from: Data(json.utf8))
+        #expect(dto.playbookId == "pb-1")
+        #expect(dto.sectionType == "VISION")
+        #expect(dto.content == "Build something great")
+    }
+
+    @Test("WeeklyCycleDTO Codable roundtrip with snake_case")
+    func weeklyCycleDTOCodable() throws {
+        let json = """
+        {
+            "id": "wc-1",
+            "playbook_id": "pb-1",
+            "week_start_date": "2026-01-06T00:00:00Z",
+            "completed_count": 3,
+            "total_count": 5,
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-06T00:00:00Z"
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .iso8601
+
+        let dto = try decoder.decode(WeeklyCycleDTO.self, from: Data(json.utf8))
+        #expect(dto.id == "wc-1")
+        #expect(dto.completedCount == 3)
+        #expect(dto.totalCount == 5)
+    }
+}


### PR DESCRIPTION
## Summary
- Centralized `APIClient` with typed JSON decoding (`request<T>` / `requestVoid`), Bearer token injection via `TokenProviding` protocol, and transparent 401 refresh-and-retry
- `Endpoint` struct with static factory methods for all API routes (auth, playbooks, tasks, sections, weekly cycles)
- DTOs for all API entities with `Codable` roundtrip support and `toModel()` / `toCreateDTO()` mapping extensions
- `APIError` enum for structured error handling (sessionExpired, badRequest, notFound, serverError, offline, decodingError)
- `TokenProviding` protocol to decouple from `TokenManager` (Issue #7)

## Test plan
- [x] 12 APIClient tests: GET/POST success, Bearer token injection, no-auth header, 401 refresh & retry, failed refresh → sessionExpired, 404/500/400 error mapping, decoding error, offline error, requestVoid 204
- [x] 3 Endpoint tests: auth endpoints don't require auth, playbook/task endpoint paths & methods
- [x] 5 DTO tests: AuthTokensDTO → UserSession mapping, PlaybookDTO/TaskDTO/SectionDTO/WeeklyCycleDTO Codable roundtrips with snake_case
- [x] All 51 tests pass (31 existing + 20 new)
- [x] Zero build warnings

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)