### PR TITLE
feat(auth): TokenManager with Keychain persistence

### DIFF
--- a/idea-pilot/idea-pilot/Core/Networking/DTOs/AuthDTO.swift
+++ b/idea-pilot/idea-pilot/Core/Networking/DTOs/AuthDTO.swift
@@ -31,7 +31,7 @@ nonisolated struct RefreshTokenRequestDTO: Codable, Sendable {
 extension AuthTokensDTO {
 
     /// Converts the auth response into a `UserSession` for Keychain storage.
-    func toUserSession() -> UserSession {
+    nonisolated func toUserSession() -> UserSession {
         UserSession(
             userId: userId,
             email: email,

--- a/idea-pilot/idea-pilot/Core/Networking/KeychainService.swift
+++ b/idea-pilot/idea-pilot/Core/Networking/KeychainService.swift
@@ -1,0 +1,127 @@
+//
+//  KeychainService.swift
+//  idea-pilot
+//
+//  Keychain abstraction protocol and production implementation.
+//
+
+import Foundation
+import Security
+
+// MARK: - KeychainStorable Protocol
+
+/// Abstraction over iOS Keychain for secure credential storage.
+///
+/// The real implementation (`KeychainService`) calls Security framework APIs.
+/// Tests inject `MockKeychainService` (in-memory dictionary) to avoid
+/// hitting the real Keychain.
+nonisolated protocol KeychainStorable: Sendable {
+
+    /// Saves a string value to the Keychain for the given key.
+    func save(_ value: String, forKey key: String) throws
+
+    /// Loads a string value from the Keychain for the given key.
+    ///
+    /// Returns `nil` if the item does not exist.
+    func load(forKey key: String) throws -> String?
+
+    /// Deletes the value from the Keychain for the given key.
+    ///
+    /// Does not throw if the item does not exist.
+    func delete(forKey key: String) throws
+}
+
+// MARK: - KeychainError
+
+/// Errors that can occur during Keychain operations.
+nonisolated enum KeychainError: Error, Equatable, Sendable {
+    /// A Keychain operation failed with the given `OSStatus` code.
+    case unexpectedStatus(OSStatus)
+    /// The data retrieved from Keychain could not be decoded as UTF-8 text.
+    case dataConversionError
+}
+
+// MARK: - KeychainService
+
+/// Production implementation of `KeychainStorable` using the iOS Security framework.
+///
+/// All items are stored as `kSecClassGenericPassword` entries with:
+/// - Service: `com.lifeautomation.idea-pilot`
+/// - Accessibility: `kSecAttrAccessibleAfterFirstUnlock` (background sync compatible)
+nonisolated final class KeychainService: KeychainStorable, Sendable {
+
+    private let service: String
+
+    /// Creates a Keychain service.
+    ///
+    /// - Parameter service: The `kSecAttrService` value. Defaults to `"com.lifeautomation.idea-pilot"`.
+    init(service: String = "com.lifeautomation.idea-pilot") {
+        self.service = service
+    }
+
+    func save(_ value: String, forKey key: String) throws {
+        guard let data = value.data(using: .utf8) else {
+            throw KeychainError.dataConversionError
+        }
+
+        // Delete existing item first (upsert pattern).
+        let deleteQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+        ]
+        SecItemDelete(deleteQuery as CFDictionary)
+
+        let addQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
+        ]
+
+        let status = SecItemAdd(addQuery as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+
+    func load(forKey key: String) throws -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        switch status {
+        case errSecSuccess:
+            guard let data = result as? Data,
+                  let string = String(data: data, encoding: .utf8) else {
+                throw KeychainError.dataConversionError
+            }
+            return string
+        case errSecItemNotFound:
+            return nil
+        default:
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+
+    func delete(forKey key: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+}

--- a/idea-pilot/idea-pilot/Features/Auth/Services/TokenManager.swift
+++ b/idea-pilot/idea-pilot/Features/Auth/Services/TokenManager.swift
@@ -1,0 +1,244 @@
+//
+//  TokenManager.swift
+//  idea-pilot
+//
+//  Manages JWT token storage, retrieval, and refresh.
+//  Stores tokens in the iOS Keychain via `KeychainStorable`.
+//
+
+import Foundation
+
+// MARK: - TokenManagerError
+
+/// Errors specific to `TokenManager` operations.
+nonisolated enum TokenManagerError: Error, Sendable {
+    /// No refresh token is stored; the user must sign in again.
+    case noRefreshToken
+    /// The refresh network request failed.
+    case refreshFailed(underlying: (any Error)?)
+}
+
+// MARK: - TokenManager
+
+/// Manages authentication tokens with Keychain persistence and in-memory caching.
+///
+/// `TokenManager` is an `actor` that provides thread-safe access to JWT tokens.
+/// It conforms to `TokenProviding` so `APIClient` can use it for Bearer token
+/// injection and transparent 401 refresh-and-retry.
+///
+/// **Storage**: Tokens are persisted as separate Keychain items under the service
+/// name `com.lifeautomation.idea-pilot` with `kSecAttrAccessibleAfterFirstUnlock`
+/// for background sync compatibility.
+///
+/// **Caching**: Keychain values are cached in-memory on the actor to avoid
+/// repeated IPC calls to `securityd`. The cache is populated lazily on first
+/// read or eagerly when `storeSession(_:)` is called.
+///
+/// **Refresh**: The actor calls the refresh endpoint directly via `URLSession`
+/// (not through `APIClient`) to avoid a circular dependency.
+///
+/// Usage:
+/// ```swift
+/// let tokenManager = TokenManager(keychain: KeychainService(), baseURL: apiURL)
+/// let client = APIClient(baseURL: apiURL, tokenProvider: tokenManager)
+/// ```
+nonisolated actor TokenManager: TokenProviding {
+
+    // MARK: - Keychain Keys
+
+    private enum Keys {
+        static let accessToken = "com.lifeautomation.idea-pilot.accessToken"
+        static let refreshToken = "com.lifeautomation.idea-pilot.refreshToken"
+        static let userId = "com.lifeautomation.idea-pilot.userId"
+        static let email = "com.lifeautomation.idea-pilot.email"
+    }
+
+    // MARK: - Dependencies
+
+    private let keychain: any KeychainStorable
+    private let baseURL: URL
+    private let session: URLSession
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    // MARK: - In-Memory Cache
+
+    private var _accessToken: String?
+    private var _refreshToken: String?
+    private var _userId: String?
+    private var _email: String?
+    private var cacheLoaded = false
+
+    // MARK: - Init
+
+    /// Creates a TokenManager.
+    ///
+    /// - Parameters:
+    ///   - keychain: The Keychain storage backend. Injectable for testing.
+    ///   - baseURL: The API base URL for the refresh endpoint.
+    ///   - session: The `URLSession` for refresh requests. Injectable for testing.
+    init(
+        keychain: any KeychainStorable = KeychainService(),
+        baseURL: URL,
+        session: URLSession = .shared
+    ) {
+        self.keychain = keychain
+        self.baseURL = baseURL
+        self.session = session
+
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        self.encoder = encoder
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .iso8601
+        self.decoder = decoder
+    }
+
+    // MARK: - TokenProviding Conformance
+
+    /// The current access token, or `nil` if the user is not authenticated.
+    var accessToken: String? {
+        loadCacheIfNeeded()
+        return _accessToken
+    }
+
+    /// Attempts to refresh the access token using the stored refresh token.
+    ///
+    /// Calls `POST /v1/auth/refresh` directly via `URLSession` (not `APIClient`)
+    /// to avoid a circular dependency. On success, updates both Keychain and cache.
+    func refresh() async throws {
+        loadCacheIfNeeded()
+
+        guard let refreshToken = _refreshToken else {
+            throw TokenManagerError.noRefreshToken
+        }
+
+        let dto = RefreshTokenRequestDTO(refreshToken: refreshToken)
+        let body = try encoder.encode(dto)
+
+        let url = baseURL.appendingPathComponent("/v1/auth/refresh")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.httpBody = body
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let data: Data
+        let response: URLResponse
+
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw TokenManagerError.refreshFailed(underlying: error)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            throw TokenManagerError.refreshFailed(underlying: nil)
+        }
+
+        let tokens: AuthTokensDTO
+        do {
+            tokens = try decoder.decode(AuthTokensDTO.self, from: data)
+        } catch {
+            throw TokenManagerError.refreshFailed(underlying: error)
+        }
+
+        try storeSession(tokens.toUserSession())
+    }
+
+    /// Clears all stored tokens from both Keychain and in-memory cache.
+    ///
+    /// Called on explicit sign-out or when a refresh attempt fails.
+    /// Keychain delete errors are logged but do not throw — best-effort cleanup.
+    func clearTokens() {
+        _accessToken = nil
+        _refreshToken = nil
+        _userId = nil
+        _email = nil
+        cacheLoaded = true
+
+        for key in [Keys.accessToken, Keys.refreshToken, Keys.userId, Keys.email] {
+            do {
+                try keychain.delete(forKey: key)
+            } catch {
+                #if DEBUG
+                print("[TokenManager] Warning: Failed to delete Keychain item '\(key)': \(error)")
+                #endif
+            }
+        }
+    }
+
+    // MARK: - Public API (beyond TokenProviding)
+
+    /// Whether the user has a stored access token.
+    var isAuthenticated: Bool {
+        loadCacheIfNeeded()
+        return _accessToken != nil
+    }
+
+    /// The stored user ID, or `nil` if not authenticated.
+    var userId: String? {
+        loadCacheIfNeeded()
+        return _userId
+    }
+
+    /// The stored email, or `nil` if not authenticated.
+    var email: String? {
+        loadCacheIfNeeded()
+        return _email
+    }
+
+    /// The current user session reconstructed from cached values, or `nil` if not authenticated.
+    var currentSession: UserSession? {
+        loadCacheIfNeeded()
+        guard let accessToken = _accessToken,
+              let refreshToken = _refreshToken,
+              let userId = _userId,
+              let email = _email else {
+            return nil
+        }
+        return UserSession(
+            userId: userId,
+            email: email,
+            accessToken: accessToken,
+            refreshToken: refreshToken
+        )
+    }
+
+    /// Stores a complete user session in both Keychain and cache.
+    ///
+    /// Called after successful login or token refresh.
+    ///
+    /// - Parameter session: The user session to persist.
+    /// - Throws: `KeychainError` if any Keychain write fails.
+    func storeSession(_ session: UserSession) throws {
+        try keychain.save(session.accessToken, forKey: Keys.accessToken)
+        try keychain.save(session.refreshToken, forKey: Keys.refreshToken)
+        try keychain.save(session.userId, forKey: Keys.userId)
+        try keychain.save(session.email, forKey: Keys.email)
+
+        _accessToken = session.accessToken
+        _refreshToken = session.refreshToken
+        _userId = session.userId
+        _email = session.email
+        cacheLoaded = true
+    }
+
+    // MARK: - Private
+
+    /// Loads all Keychain values into the in-memory cache once.
+    ///
+    /// Read failures return `nil` for that field (graceful degradation).
+    private func loadCacheIfNeeded() {
+        guard !cacheLoaded else { return }
+        cacheLoaded = true
+
+        _accessToken = try? keychain.load(forKey: Keys.accessToken)
+        _refreshToken = try? keychain.load(forKey: Keys.refreshToken)
+        _userId = try? keychain.load(forKey: Keys.userId)
+        _email = try? keychain.load(forKey: Keys.email)
+    }
+}

--- a/idea-pilot/idea-pilotTests/TokenManagerTests.swift
+++ b/idea-pilot/idea-pilotTests/TokenManagerTests.swift
@@ -1,0 +1,347 @@
+//
+//  TokenManagerTests.swift
+//  idea-pilotTests
+//
+//  Unit tests for TokenManager with mock Keychain and mock network.
+//
+
+import Foundation
+import Testing
+@testable import idea_pilot
+
+// MARK: - Mock Keychain Service
+
+/// In-memory Keychain replacement for testing.
+nonisolated final class MockKeychainService: KeychainStorable, @unchecked Sendable {
+
+    nonisolated(unsafe) var storage: [String: String] = [:]
+    nonisolated(unsafe) var saveCallCount = 0
+    nonisolated(unsafe) var loadCallCount = 0
+    nonisolated(unsafe) var deleteCallCount = 0
+    nonisolated(unsafe) var shouldThrowOnSave = false
+    nonisolated(unsafe) var shouldThrowOnLoad = false
+    nonisolated(unsafe) var shouldThrowOnDelete = false
+
+    func save(_ value: String, forKey key: String) throws {
+        saveCallCount += 1
+        if shouldThrowOnSave {
+            throw KeychainError.unexpectedStatus(-25300)
+        }
+        storage[key] = value
+    }
+
+    func load(forKey key: String) throws -> String? {
+        loadCallCount += 1
+        if shouldThrowOnLoad {
+            throw KeychainError.unexpectedStatus(-25300)
+        }
+        return storage[key]
+    }
+
+    func delete(forKey key: String) throws {
+        deleteCallCount += 1
+        if shouldThrowOnDelete {
+            throw KeychainError.unexpectedStatus(-25300)
+        }
+        storage.removeValue(forKey: key)
+    }
+}
+
+// MARK: - Mock URL Protocol (separate from APIClientTests to avoid shared state)
+
+/// A `URLProtocol` subclass for TokenManager tests, independent of `MockURLProtocol`.
+final class TokenMockURLProtocol: URLProtocol, @unchecked Sendable {
+
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> (Data, HTTPURLResponse))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = TokenMockURLProtocol.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+
+        do {
+            let (data, response) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Test Helpers
+
+private let testBaseURL = URL(string: "https://api.test.ideapilot.app")!
+
+private func makeURLSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [TokenMockURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+private nonisolated func makeResponse(statusCode: Int) -> HTTPURLResponse {
+    HTTPURLResponse(
+        url: testBaseURL,
+        statusCode: statusCode,
+        httpVersion: nil,
+        headerFields: nil
+    )!
+}
+
+private func makeUserSession() -> UserSession {
+    UserSession(
+        userId: "user-123",
+        email: "test@example.com",
+        accessToken: "access-token-abc",
+        refreshToken: "refresh-token-xyz"
+    )
+}
+
+// MARK: - TokenManager Tests
+
+@Suite("TokenManager", .serialized)
+struct TokenManagerTests {
+
+    // MARK: - Storage
+
+    @Test("storeSession persists all four fields to Keychain")
+    func storeSessionPersists() async throws {
+        let keychain = MockKeychainService()
+        let manager = TokenManager(keychain: keychain, baseURL: testBaseURL)
+
+        try await manager.storeSession(makeUserSession())
+
+        #expect(keychain.storage["com.lifeautomation.idea-pilot.accessToken"] == "access-token-abc")
+        #expect(keychain.storage["com.lifeautomation.idea-pilot.refreshToken"] == "refresh-token-xyz")
+        #expect(keychain.storage["com.lifeautomation.idea-pilot.userId"] == "user-123")
+        #expect(keychain.storage["com.lifeautomation.idea-pilot.email"] == "test@example.com")
+        #expect(keychain.saveCallCount == 4)
+    }
+
+    @Test("accessToken returns stored value from cache")
+    func accessTokenFromCache() async throws {
+        let keychain = MockKeychainService()
+        let manager = TokenManager(keychain: keychain, baseURL: testBaseURL)
+        try await manager.storeSession(makeUserSession())
+
+        let token = await manager.accessToken
+        #expect(token == "access-token-abc")
+    }
+
+    @Test("accessToken loads from Keychain on first access")
+    func accessTokenLoadsFromKeychain() async {
+        let keychain = MockKeychainService()
+        keychain.storage["com.lifeautomation.idea-pilot.accessToken"] = "persisted-token"
+        keychain.storage["com.lifeautomation.idea-pilot.refreshToken"] = "persisted-refresh"
+
+        let manager = TokenManager(keychain: keychain, baseURL: testBaseURL)
+        let token = await manager.accessToken
+        #expect(token == "persisted-token")
+    }
+
+    @Test("accessToken returns nil when no tokens stored")
+    func accessTokenNilWhenEmpty() async {
+        let keychain = MockKeychainService()
+        let manager = TokenManager(keychain: keychain, baseURL: testBaseURL)
+
+        let token = await manager.accessToken
+        #expect(token == nil)
+    }
+
+    // MARK: - isAuthenticated
+
+    @Test("isAuthenticated is true after storeSession")
+    func isAuthenticatedAfterStore() async throws {
+        let keychain = MockKeychainService()
+        let manager = TokenManager(keychain: keychain, baseURL: testBaseURL)
+        try await manager.storeSession(makeUserSession())
+
+        let authed = await manager.isAuthenticated
+        #expect(authed == true)
+    }
+
+    @Test("isAuthenticated is false when no tokens")
+    func isAuthenticatedWhenEmpty() async {
+        let keychain = MockKeychainService()
+        let manager = TokenManager(keychain: keychain, baseURL: testBaseURL)
+
+        let authed = await manager.isAuthenticated
+        #expect(authed == false)
+    }
+
+    @Test("isAuthenticated is false after clearTokens")
+    func isAuthenticatedAfterClear() async throws {
+        let keychain = MockKeychainService()
+        let manager = TokenManager(keychain: keychain, baseURL: testBaseURL)
+        try await manager.storeSession(makeUserSession())
+        await manager.clearTokens()
+
+        let authed = await manager.isAuthenticated
+        #expect(authed == false)
+    }
+
+    // MARK: - clearTokens
+
+    @Test("clearTokens removes all four Keychain items and clears cache")
+    func clearTokensRemovesAll() async throws {
+        let keychain = MockKeychainService()
+        let manager = TokenManager(keychain: keychain, baseURL: testBaseURL)
+        try await manager.storeSession(makeUserSession())
+
+        await manager.clearTokens()
+
+        #expect(await manager.accessToken == nil)
+        #expect(keychain.storage.isEmpty)
+        #expect(keychain.deleteCallCount == 4)
+    }
+
+    @Test("clearTokens does not throw when Keychain delete fails")
+    func clearTokensGracefulOnDeleteFailure() async throws {
+        let keychain = MockKeychainService()
+        let manager = TokenManager(keychain: keychain, baseURL: testBaseURL)
+        try await manager.storeSession(makeUserSession())
+
+        keychain.shouldThrowOnDelete = true
+        await manager.clearTokens()
+
+        // Cache should still be cleared even if Keychain delete failed.
+        #expect(await manager.accessToken == nil)
+    }
+
+    // MARK: - refresh
+
+    @Test("refresh updates tokens on successful API response")
+    func refreshSuccess() async throws {
+        let keychain = MockKeychainService()
+        keychain.storage["com.lifeautomation.idea-pilot.refreshToken"] = "old-refresh"
+        keychain.storage["com.lifeautomation.idea-pilot.accessToken"] = "old-access"
+
+        let responseJSON = #"{"access_token":"new-access","refresh_token":"new-refresh","user_id":"user-1","email":"a@b.com"}"#
+        TokenMockURLProtocol.handler = { request in
+            return (Data(responseJSON.utf8), makeResponse(statusCode: 200))
+        }
+
+        let manager = TokenManager(keychain: keychain, baseURL: testBaseURL, session: makeURLSession())
+
+        try await manager.refresh()
+
+        #expect(await manager.accessToken == "new-access")
+        #expect(keychain.storage["com.lifeautomation.idea-pilot.accessToken"] == "new-access")
+        #expect(keychain.storage["com.lifeautomation.idea-pilot.refreshToken"] == "new-refresh")
+        #expect(keychain.storage["com.lifeautomation.idea-pilot.userId"] == "user-1")
+        #expect(keychain.storage["com.lifeautomation.idea-pilot.email"] == "a@b.com")
+        TokenMockURLProtocol.handler = nil
+    }
+
+    @Test("refresh throws noRefreshToken when no refresh token stored")
+    func refreshThrowsNoRefreshToken() async {
+        let keychain = MockKeychainService()
+        let manager = TokenManager(keychain: keychain, baseURL: testBaseURL)
+
+        do {
+            try await manager.refresh()
+            Issue.record("Expected TokenManagerError.noRefreshToken")
+        } catch let error as TokenManagerError {
+            guard case .noRefreshToken = error else {
+                Issue.record("Expected noRefreshToken, got \(error)")
+                return
+            }
+        } catch {
+            Issue.record("Unexpected error type: \(error)")
+        }
+    }
+
+    @Test("refresh throws refreshFailed on non-2xx response")
+    func refreshThrowsOnServerError() async {
+        let keychain = MockKeychainService()
+        keychain.storage["com.lifeautomation.idea-pilot.refreshToken"] = "some-refresh"
+        keychain.storage["com.lifeautomation.idea-pilot.accessToken"] = "some-access"
+
+        TokenMockURLProtocol.handler = { _ in
+            (Data(), makeResponse(statusCode: 401))
+        }
+
+        let manager = TokenManager(keychain: keychain, baseURL: testBaseURL, session: makeURLSession())
+
+        do {
+            try await manager.refresh()
+            Issue.record("Expected TokenManagerError.refreshFailed")
+        } catch let error as TokenManagerError {
+            guard case .refreshFailed = error else {
+                Issue.record("Expected refreshFailed, got \(error)")
+                return
+            }
+        } catch {
+            Issue.record("Unexpected error type: \(error)")
+        }
+        TokenMockURLProtocol.handler = nil
+    }
+
+    // MARK: - Keychain Error Handling
+
+    @Test("accessToken returns nil gracefully when Keychain read fails")
+    func accessTokenGracefulOnReadFailure() async {
+        let keychain = MockKeychainService()
+        keychain.shouldThrowOnLoad = true
+
+        let manager = TokenManager(keychain: keychain, baseURL: testBaseURL)
+        let token = await manager.accessToken
+        #expect(token == nil)
+    }
+
+    @Test("storeSession throws when Keychain write fails")
+    func storeSessionThrowsOnWriteFailure() async {
+        let keychain = MockKeychainService()
+        keychain.shouldThrowOnSave = true
+
+        let manager = TokenManager(keychain: keychain, baseURL: testBaseURL)
+
+        do {
+            try await manager.storeSession(makeUserSession())
+            Issue.record("Expected KeychainError")
+        } catch {
+            #expect(error is KeychainError)
+        }
+    }
+
+    // MARK: - userId and email
+
+    @Test("userId and email available after storeSession")
+    func userIdAndEmail() async throws {
+        let keychain = MockKeychainService()
+        let manager = TokenManager(keychain: keychain, baseURL: testBaseURL)
+        try await manager.storeSession(UserSession(
+            userId: "user-42",
+            email: "harold@example.com",
+            accessToken: "a",
+            refreshToken: "r"
+        ))
+
+        #expect(await manager.userId == "user-42")
+        #expect(await manager.email == "harold@example.com")
+    }
+
+    // MARK: - Persistence Across Instances
+
+    @Test("tokens persist across TokenManager instances (simulated app relaunch)")
+    func persistenceAcrossInstances() async throws {
+        let keychain = MockKeychainService()
+
+        let manager1 = TokenManager(keychain: keychain, baseURL: testBaseURL)
+        try await manager1.storeSession(makeUserSession())
+
+        let manager2 = TokenManager(keychain: keychain, baseURL: testBaseURL)
+        let token = await manager2.accessToken
+        #expect(token == "access-token-abc")
+
+        let authed = await manager2.isAuthenticated
+        #expect(authed == true)
+    }
+}


### PR DESCRIPTION
## Summary
- `KeychainStorable` protocol + `KeychainService` implementation using iOS Security framework with `kSecAttrAccessibleAfterFirstUnlock` for background sync
- `TokenManager` actor conforming to `TokenProviding` with in-memory caching and lazy Keychain loading
- Direct `URLSession` refresh call to `POST /v1/auth/refresh` (avoids circular APIClient dependency)
- 4 separate Keychain items: accessToken, refreshToken, userId, email (service: `com.lifeautomation.idea-pilot`)
- `isAuthenticated`, `userId`, `email`, `currentSession` computed properties beyond the protocol
- Fix: `AuthTokensDTO.toUserSession()` marked `nonisolated` for use from non-MainActor contexts

## Test plan
- [x] 16 TokenManager tests with `MockKeychainService` (in-memory dictionary)
- [x] Store/load/clear tokens, persistence across instances, isAuthenticated lifecycle
- [x] Refresh success with mock network, refresh failure cases (no token, server error)
- [x] Keychain error handling: graceful read failure, write failure throws, delete failure non-throwing
- [x] All 67 tests pass (51 existing + 16 new)
- [x] Zero build warnings

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)