### PR TITLE
feat(config): build-configuration-based AppConfiguration

### DIFF
--- a/idea-pilot/idea-pilot/Core/AppConfiguration.swift
+++ b/idea-pilot/idea-pilot/Core/AppConfiguration.swift
@@ -1,0 +1,62 @@
+//
+//  AppConfiguration.swift
+//  idea-pilot
+//
+//  Centralized app configuration with compile-time API URL switching.
+//
+
+import Foundation
+
+/// Centralized configuration for the Idea Pilot app.
+///
+/// Provides build-configuration-based values such as the API base URL,
+/// app version, and build number. Debug builds point to localhost;
+/// Release builds point to the production API.
+///
+/// Usage:
+/// ```swift
+/// let client = APIClient(baseURL: AppConfiguration.apiBaseURL)
+/// let version = AppConfiguration.appVersion
+/// ```
+nonisolated enum AppConfiguration {
+
+    /// The base URL for all API requests.
+    ///
+    /// - Debug: `http://localhost:5003` (local development server)
+    /// - Release: `https://api.ideapilot.app` (production)
+    static let apiBaseURL: URL = {
+        #if DEBUG
+        URL(string: "http://localhost:5003")!
+        #else
+        URL(string: "https://api.ideapilot.app")!
+        #endif
+    }()
+
+    /// The app version string from the main bundle (e.g., `"1.0.0"`).
+    ///
+    /// Returns `"0.0.0"` if the key is missing (should not happen in production).
+    static var appVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+    }
+
+    /// The build number string from the main bundle (e.g., `"42"`).
+    ///
+    /// Returns `"0"` if the key is missing.
+    static var buildNumber: String {
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
+    }
+
+    /// A formatted version string suitable for display (e.g., `"1.0.0 (42)"`).
+    static var versionDisplay: String {
+        "\(appVersion) (\(buildNumber))"
+    }
+
+    /// Whether the app is running in a Debug build configuration.
+    static let isDebug: Bool = {
+        #if DEBUG
+        true
+        #else
+        false
+        #endif
+    }()
+}

--- a/idea-pilot/idea-pilotTests/AppConfigurationTests.swift
+++ b/idea-pilot/idea-pilotTests/AppConfigurationTests.swift
@@ -1,0 +1,51 @@
+//
+//  AppConfigurationTests.swift
+//  idea-pilotTests
+//
+//  Unit tests for AppConfiguration.
+//
+
+import Foundation
+import Testing
+@testable import idea_pilot
+
+@Suite("AppConfiguration")
+struct AppConfigurationTests {
+
+    @Test("apiBaseURL returns localhost in Debug builds")
+    func apiBaseURLDebug() {
+        // Tests run under the Debug configuration.
+        #expect(AppConfiguration.apiBaseURL.absoluteString == "http://localhost:5003")
+    }
+
+    @Test("apiBaseURL is a valid URL")
+    func apiBaseURLValid() {
+        let url = AppConfiguration.apiBaseURL
+        #expect(url.scheme == "http" || url.scheme == "https")
+        #expect(url.host != nil)
+    }
+
+    @Test("isDebug is true in test builds")
+    func isDebugTrue() {
+        #expect(AppConfiguration.isDebug == true)
+    }
+
+    @Test("appVersion returns a non-empty string")
+    func appVersionNonEmpty() {
+        #expect(!AppConfiguration.appVersion.isEmpty)
+    }
+
+    @Test("buildNumber returns a non-empty string")
+    func buildNumberNonEmpty() {
+        #expect(!AppConfiguration.buildNumber.isEmpty)
+    }
+
+    @Test("versionDisplay combines version and build number")
+    func versionDisplayFormat() {
+        let display = AppConfiguration.versionDisplay
+        #expect(display.contains("("))
+        #expect(display.contains(")"))
+        #expect(display.contains(AppConfiguration.appVersion))
+        #expect(display.contains(AppConfiguration.buildNumber))
+    }
+}


### PR DESCRIPTION
## Summary
- `AppConfiguration` enum with compile-time `#if DEBUG` API URL switching (localhost:5003 vs production)
- `appVersion`, `buildNumber`, `versionDisplay` accessors from main Bundle
- `isDebug` flag for conditional behavior

## Test plan
- [x] 6 AppConfiguration tests: apiBaseURL returns localhost in Debug, URL is valid, isDebug true, appVersion/buildNumber non-empty, versionDisplay format
- [x] All 73 tests pass (67 existing + 6 new)
- [x] Zero build warnings

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)