### PR TITLE
feat(auth): add AuthService — login, register, Auth0, logout (#9)

### DIFF
--- a/idea-pilot/idea-pilot/Core/Networking/DTOs/AuthDTO.swift
+++ b/idea-pilot/idea-pilot/Core/Networking/DTOs/AuthDTO.swift
@@ -21,6 +21,17 @@ nonisolated struct AuthTokensDTO: Codable, Sendable {
     let email: String
 }
 
+/// Request body for `POST /v1/auth/register`.
+nonisolated struct RegisterRequestDTO: Codable, Sendable {
+    let email: String
+    let password: String
+}
+
+/// Request body for `POST /v1/auth/auth0`.
+nonisolated struct Auth0RequestDTO: Codable, Sendable {
+    let idToken: String
+}
+
 /// Request body for `POST /v1/auth/refresh`.
 nonisolated struct RefreshTokenRequestDTO: Codable, Sendable {
     let refreshToken: String

--- a/idea-pilot/idea-pilot/Core/Networking/Endpoint.swift
+++ b/idea-pilot/idea-pilot/Core/Networking/Endpoint.swift
@@ -59,6 +59,18 @@ extension Endpoint {
     static func refreshToken(dto: RefreshTokenRequestDTO) -> Endpoint {
         Endpoint(path: "/v1/auth/refresh", method: .post, body: dto, requiresAuth: false)
     }
+
+    static func register(dto: RegisterRequestDTO) -> Endpoint {
+        Endpoint(path: "/v1/auth/register", method: .post, body: dto, requiresAuth: false)
+    }
+
+    static func auth0(dto: Auth0RequestDTO) -> Endpoint {
+        Endpoint(path: "/v1/auth/auth0", method: .post, body: dto, requiresAuth: false)
+    }
+
+    static func logout() -> Endpoint {
+        Endpoint(path: "/v1/auth/logout", method: .post)
+    }
 }
 
 // MARK: - Playbook Endpoints

--- a/idea-pilot/idea-pilot/Features/Auth/Services/AuthService.swift
+++ b/idea-pilot/idea-pilot/Features/Auth/Services/AuthService.swift
@@ -1,0 +1,150 @@
+//
+//  AuthService.swift
+//  idea-pilot
+//
+//  Orchestrates authentication flows: login, registration, Auth0, and logout.
+//
+
+import Foundation
+import SwiftData
+
+// MARK: - AuthError
+
+/// Errors specific to authentication operations.
+nonisolated enum AuthError: Error, Equatable, Sendable {
+    /// Email/password combination is incorrect (401 on login).
+    case invalidCredentials
+    /// The email is already registered (400 with "already exists").
+    case emailAlreadyExists
+    /// A network-level failure occurred.
+    case networkError(String)
+    /// The server returned an unexpected error.
+    case serverError(String)
+}
+
+// MARK: - AuthServiceProtocol
+
+/// Defines the authentication API surface for testability.
+nonisolated protocol AuthServiceProtocol: Sendable {
+    func login(email: String, password: String) async throws -> UserSession
+    func register(email: String, password: String) async throws -> UserSession
+    func auth0Login(idToken: String) async throws -> UserSession
+    func logout() async throws
+}
+
+// MARK: - AuthService
+
+/// Coordinates authentication flows through `APIClient` and `TokenManager`.
+///
+/// Each sign-in method (email/password, Auth0) follows the same pattern:
+/// 1. Call the API endpoint
+/// 2. Store the resulting session in TokenManager
+/// 3. Return the `UserSession`
+///
+/// Logout performs a best-effort server call, then always clears local state
+/// (tokens + SwiftData) regardless of network outcome.
+final class AuthService: AuthServiceProtocol, Sendable {
+
+    private let apiClient: APIClient
+    private let tokenManager: TokenManager
+    private let modelContainer: ModelContainer
+
+    /// Creates an AuthService.
+    ///
+    /// - Parameters:
+    ///   - apiClient: The networking client for API calls.
+    ///   - tokenManager: Manages token storage and refresh.
+    ///   - modelContainer: The SwiftData container for clearing local data on logout.
+    init(apiClient: APIClient, tokenManager: TokenManager, modelContainer: ModelContainer) {
+        self.apiClient = apiClient
+        self.tokenManager = tokenManager
+        self.modelContainer = modelContainer
+    }
+
+    func login(email: String, password: String) async throws -> UserSession {
+        let dto = LoginRequestDTO(email: email, password: password)
+        let tokens: AuthTokensDTO
+        do {
+            tokens = try await apiClient.request(.login(dto: dto))
+        } catch let error as APIError {
+            throw mapAuthError(error, context: .login)
+        }
+
+        let session = tokens.toUserSession()
+        try await tokenManager.storeSession(session)
+        return session
+    }
+
+    func register(email: String, password: String) async throws -> UserSession {
+        let dto = RegisterRequestDTO(email: email, password: password)
+        let tokens: AuthTokensDTO
+        do {
+            tokens = try await apiClient.request(.register(dto: dto))
+        } catch let error as APIError {
+            throw mapAuthError(error, context: .register)
+        }
+
+        let session = tokens.toUserSession()
+        try await tokenManager.storeSession(session)
+        return session
+    }
+
+    func auth0Login(idToken: String) async throws -> UserSession {
+        let dto = Auth0RequestDTO(idToken: idToken)
+        let tokens: AuthTokensDTO
+        do {
+            tokens = try await apiClient.request(.auth0(dto: dto))
+        } catch let error as APIError {
+            throw mapAuthError(error, context: .auth0)
+        }
+
+        let session = tokens.toUserSession()
+        try await tokenManager.storeSession(session)
+        return session
+    }
+
+    func logout() async throws {
+        // Best-effort server-side token invalidation.
+        try? await apiClient.requestVoid(.logout())
+
+        // Always clear local state regardless of server response.
+        await tokenManager.clearTokens()
+        try await clearLocalData()
+    }
+
+    // MARK: - Private
+
+    private enum AuthContext {
+        case login, register, auth0
+    }
+
+    private func mapAuthError(_ error: APIError, context: AuthContext) -> AuthError {
+        switch error {
+        case .sessionExpired:
+            return .invalidCredentials
+        case .badRequest(let message):
+            if context == .register,
+               let msg = message?.lowercased(),
+               msg.contains("already") || msg.contains("exists") {
+                return .emailAlreadyExists
+            }
+            return .serverError(message ?? "Bad request")
+        case .networkError(let urlError):
+            return .networkError(urlError.localizedDescription)
+        case .offline:
+            return .networkError("No internet connection")
+        case .notFound:
+            return .serverError("Endpoint not found")
+        case .serverError(_, let message):
+            return .serverError(message ?? "Server error")
+        case .decodingError(let message):
+            return .serverError("Invalid response: \(message)")
+        }
+    }
+
+    @MainActor
+    private func clearLocalData() throws {
+        let context = modelContainer.mainContext
+        try context.delete(model: PlaybookModel.self)
+    }
+}

--- a/idea-pilot/idea-pilotTests/AuthServiceTests.swift
+++ b/idea-pilot/idea-pilotTests/AuthServiceTests.swift
@@ -1,0 +1,324 @@
+//
+//  AuthServiceTests.swift
+//  idea-pilotTests
+//
+//  Unit tests for AuthService with mock networking and in-memory SwiftData.
+//
+
+import Foundation
+import SwiftData
+import Testing
+@testable import idea_pilot
+
+// MARK: - Mock URL Protocol (independent from other test suites)
+
+/// A `URLProtocol` subclass for AuthService tests, independent of other mocks.
+final class AuthServiceMockURLProtocol: URLProtocol, @unchecked Sendable {
+
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> (Data, HTTPURLResponse))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = AuthServiceMockURLProtocol.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+
+        do {
+            let (data, response) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Test Helpers
+
+private let testBaseURL = URL(string: "https://api.test.ideapilot.app")!
+
+private func makeURLSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [AuthServiceMockURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+private nonisolated func makeResponse(statusCode: Int) -> HTTPURLResponse {
+    HTTPURLResponse(
+        url: testBaseURL,
+        statusCode: statusCode,
+        httpVersion: nil,
+        headerFields: nil
+    )!
+}
+
+private let successTokensJSON = #"""
+{
+    "access_token": "new-access",
+    "refresh_token": "new-refresh",
+    "user_id": "user-1",
+    "email": "test@example.com"
+}
+"""#
+
+private nonisolated func makeInMemoryModelContainer() throws -> ModelContainer {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    return try ModelContainer(
+        for: PlaybookModel.self, TaskModel.self, SectionModel.self, WeeklyCycleModel.self,
+        configurations: config
+    )
+}
+
+private nonisolated func makeAuthService(
+    keychain: MockKeychainService = MockKeychainService(),
+    session: URLSession? = nil
+) throws -> (AuthService, TokenManager, MockKeychainService, ModelContainer) {
+    let urlSession = session ?? makeURLSession()
+    let tokenManager = TokenManager(keychain: keychain, baseURL: testBaseURL, session: urlSession)
+    let apiClient = APIClient(baseURL: testBaseURL, session: urlSession, tokenProvider: tokenManager)
+    let container = try makeInMemoryModelContainer()
+    let authService = AuthService(apiClient: apiClient, tokenManager: tokenManager, modelContainer: container)
+    return (authService, tokenManager, keychain, container)
+}
+
+// MARK: - AuthService Tests
+
+@Suite("AuthService", .serialized)
+struct AuthServiceTests {
+
+    // MARK: - Login
+
+    @Test("login success stores session and returns UserSession")
+    func loginSuccess() async throws {
+        AuthServiceMockURLProtocol.handler = { _ in
+            (Data(successTokensJSON.utf8), makeResponse(statusCode: 200))
+        }
+
+        let (authService, tokenManager, _, _) = try makeAuthService()
+
+        let session = try await authService.login(email: "test@example.com", password: "password123")
+
+        #expect(session.userId == "user-1")
+        #expect(session.email == "test@example.com")
+        #expect(session.accessToken == "new-access")
+        #expect(session.refreshToken == "new-refresh")
+
+        let storedToken = await tokenManager.accessToken
+        #expect(storedToken == "new-access")
+
+        AuthServiceMockURLProtocol.handler = nil
+    }
+
+    @Test("login with invalid credentials throws invalidCredentials")
+    func loginInvalidCredentials() async throws {
+        AuthServiceMockURLProtocol.handler = { _ in
+            (Data(), makeResponse(statusCode: 401))
+        }
+
+        let (authService, _, _, _) = try makeAuthService()
+
+        do {
+            _ = try await authService.login(email: "wrong@example.com", password: "bad")
+            Issue.record("Expected AuthError.invalidCredentials")
+        } catch let error as AuthError {
+            #expect(error == .invalidCredentials)
+        }
+
+        AuthServiceMockURLProtocol.handler = nil
+    }
+
+    // MARK: - Register
+
+    @Test("register success stores session and returns UserSession")
+    func registerSuccess() async throws {
+        AuthServiceMockURLProtocol.handler = { _ in
+            (Data(successTokensJSON.utf8), makeResponse(statusCode: 200))
+        }
+
+        let (authService, tokenManager, _, _) = try makeAuthService()
+
+        let session = try await authService.register(email: "new@example.com", password: "password123")
+
+        #expect(session.userId == "user-1")
+        #expect(session.accessToken == "new-access")
+
+        let storedToken = await tokenManager.accessToken
+        #expect(storedToken == "new-access")
+
+        AuthServiceMockURLProtocol.handler = nil
+    }
+
+    @Test("register with existing email throws emailAlreadyExists")
+    func registerEmailAlreadyExists() async throws {
+        let errorJSON = #"{"message":"Email already exists"}"#
+        AuthServiceMockURLProtocol.handler = { _ in
+            (Data(errorJSON.utf8), makeResponse(statusCode: 400))
+        }
+
+        let (authService, _, _, _) = try makeAuthService()
+
+        do {
+            _ = try await authService.register(email: "taken@example.com", password: "password123")
+            Issue.record("Expected AuthError.emailAlreadyExists")
+        } catch let error as AuthError {
+            #expect(error == .emailAlreadyExists)
+        }
+
+        AuthServiceMockURLProtocol.handler = nil
+    }
+
+    // MARK: - Auth0 Login
+
+    @Test("auth0Login success stores session and returns UserSession")
+    func auth0LoginSuccess() async throws {
+        AuthServiceMockURLProtocol.handler = { _ in
+            (Data(successTokensJSON.utf8), makeResponse(statusCode: 200))
+        }
+
+        let (authService, tokenManager, _, _) = try makeAuthService()
+
+        let session = try await authService.auth0Login(idToken: "auth0-id-token-xyz")
+
+        #expect(session.userId == "user-1")
+        #expect(session.email == "test@example.com")
+        #expect(session.accessToken == "new-access")
+
+        let storedToken = await tokenManager.accessToken
+        #expect(storedToken == "new-access")
+
+        AuthServiceMockURLProtocol.handler = nil
+    }
+
+    // MARK: - Logout
+
+    @Test("logout clears tokens and SwiftData")
+    func logoutClearsState() async throws {
+        // Set up authenticated state.
+        let keychain = MockKeychainService()
+        AuthServiceMockURLProtocol.handler = { _ in
+            (Data(), makeResponse(statusCode: 200))
+        }
+
+        let (authService, tokenManager, _, container) = try makeAuthService(keychain: keychain)
+
+        // Store a session first.
+        try await tokenManager.storeSession(UserSession(
+            userId: "user-1",
+            email: "test@example.com",
+            accessToken: "access-token",
+            refreshToken: "refresh-token"
+        ))
+
+        // Add a playbook to SwiftData.
+        let context = await container.mainContext
+        let playbook = PlaybookModel(id: "pb-1", title: "Test Playbook")
+        await context.insert(playbook)
+        try await context.save()
+
+        try await authService.logout()
+
+        let token = await tokenManager.accessToken
+        #expect(token == nil)
+
+        let isAuthed = await tokenManager.isAuthenticated
+        #expect(isAuthed == false)
+
+        AuthServiceMockURLProtocol.handler = nil
+    }
+
+    @Test("logout clears local state even if API call fails")
+    func logoutClearsStateOnNetworkFailure() async throws {
+        let keychain = MockKeychainService()
+        AuthServiceMockURLProtocol.handler = { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+
+        let (authService, tokenManager, _, _) = try makeAuthService(keychain: keychain)
+
+        // Store a session first.
+        try await tokenManager.storeSession(UserSession(
+            userId: "user-1",
+            email: "test@example.com",
+            accessToken: "access-token",
+            refreshToken: "refresh-token"
+        ))
+
+        try await authService.logout()
+
+        let token = await tokenManager.accessToken
+        #expect(token == nil)
+
+        AuthServiceMockURLProtocol.handler = nil
+    }
+
+    // MARK: - Error Mapping
+
+    @Test("login network error mapped to AuthError.networkError")
+    func loginNetworkError() async throws {
+        AuthServiceMockURLProtocol.handler = { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+
+        let (authService, _, _, _) = try makeAuthService()
+
+        do {
+            _ = try await authService.login(email: "test@example.com", password: "pass")
+            Issue.record("Expected AuthError.networkError")
+        } catch let error as AuthError {
+            guard case .networkError = error else {
+                Issue.record("Expected networkError, got \(error)")
+                return
+            }
+        }
+
+        AuthServiceMockURLProtocol.handler = nil
+    }
+
+    @Test("register server error mapped to AuthError.serverError")
+    func registerServerError() async throws {
+        let errorJSON = #"{"message":"Internal server error"}"#
+        AuthServiceMockURLProtocol.handler = { _ in
+            (Data(errorJSON.utf8), makeResponse(statusCode: 500))
+        }
+
+        let (authService, _, _, _) = try makeAuthService()
+
+        do {
+            _ = try await authService.register(email: "test@example.com", password: "pass")
+            Issue.record("Expected AuthError.serverError")
+        } catch let error as AuthError {
+            guard case .serverError = error else {
+                Issue.record("Expected serverError, got \(error)")
+                return
+            }
+        }
+
+        AuthServiceMockURLProtocol.handler = nil
+    }
+
+    @Test("login sends correct endpoint path and method")
+    func loginEndpointCorrect() async throws {
+        nonisolated(unsafe) var capturedPath: String?
+        nonisolated(unsafe) var capturedMethod: String?
+
+        AuthServiceMockURLProtocol.handler = { request in
+            capturedPath = request.url?.path
+            capturedMethod = request.httpMethod
+            return (Data(successTokensJSON.utf8), makeResponse(statusCode: 200))
+        }
+
+        let (authService, _, _, _) = try makeAuthService()
+        _ = try await authService.login(email: "test@example.com", password: "pass")
+
+        #expect(capturedPath?.contains("/v1/auth/login") == true)
+        #expect(capturedMethod == "POST")
+
+        AuthServiceMockURLProtocol.handler = nil
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `AuthService` with `AuthServiceProtocol` for login, register, Auth0 sign-in, and logout flows
- Coordinates `APIClient` requests with `TokenManager` session storage; logout clears both tokens and SwiftData
- Adds `AuthError` enum with typed error mapping from `APIError` (invalidCredentials, emailAlreadyExists, networkError, serverError)
- Adds `register`, `auth0`, and `logout` endpoint factories to `Endpoint.swift`
- Adds `RegisterRequestDTO` and `Auth0RequestDTO` to `AuthDTO.swift`
- 10 new tests with independent `AuthServiceMockURLProtocol` and in-memory `ModelContainer`

## Test plan
- [x] All 83 tests pass locally (10 new AuthService + 73 existing)
- [ ] CI passes on GitHub Actions
- [ ] Verify no force unwrapping in new code

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)