### PR TITLE
feat(nav): root navigation auth gate (#12)

### DIFF
--- a/idea-pilot/idea-pilot/App/idea_pilotApp.swift
+++ b/idea-pilot/idea-pilot/App/idea_pilotApp.swift
@@ -2,7 +2,8 @@
 //  idea_pilotApp.swift
 //  idea-pilot
 //
-//  Created by Harold Bostic on 2/21/26.
+//  Main entry point for the Idea Pilot iOS app.
+//  Bootstraps the dependency graph and sets the root view.
 //
 
 import SwiftData
@@ -10,19 +11,44 @@ import SwiftUI
 
 /// The main entry point for the Idea Pilot iOS app.
 ///
-/// Bootstraps the app window, registers the SwiftData `ModelContainer`,
-/// and sets the root view. SwiftData discovers all related models
-/// (TaskModel, SectionModel, WeeklyCycleModel) via PlaybookModel's relationships.
+/// Creates the full dependency graph at startup:
+/// `ModelContainer` → `TokenManager` → `APIClient` → `AuthService`
 ///
-/// Future milestones will add:
-/// - Environment objects for auth state and sync engine
-/// - Deep link handling
+/// These are passed to `RootView` which gates on authentication state.
 @main
 struct idea_pilotApp: App {
+
+    let modelContainer: ModelContainer
+    let tokenManager: TokenManager
+    let apiClient: APIClient
+    let authService: AuthService
+
+    init() {
+        let container = try! ModelContainer(for: PlaybookModel.self)
+        let tm = TokenManager(
+            keychain: KeychainService(),
+            baseURL: AppConfiguration.apiBaseURL
+        )
+        let client = APIClient(
+            baseURL: AppConfiguration.apiBaseURL,
+            tokenProvider: tm
+        )
+        let auth = AuthService(
+            apiClient: client,
+            tokenManager: tm,
+            modelContainer: container
+        )
+
+        self.modelContainer = container
+        self.tokenManager = tm
+        self.apiClient = client
+        self.authService = auth
+    }
+
     var body: some Scene {
         WindowGroup {
-            RootView()
+            RootView(tokenManager: tokenManager, authService: authService)
         }
-        .modelContainer(for: PlaybookModel.self)
+        .modelContainer(modelContainer)
     }
 }

--- a/idea-pilot/idea-pilot/Features/Auth/ViewModels/AuthViewModel.swift
+++ b/idea-pilot/idea-pilot/Features/Auth/ViewModels/AuthViewModel.swift
@@ -91,6 +91,20 @@ final class AuthViewModel {
         clearErrors()
     }
 
+    /// Signs the user out, clearing tokens and local data.
+    ///
+    /// Best-effort logout API call, then resets `isAuthenticated` to `false`.
+    func signOut() {
+        Task {
+            try? await authService.logout()
+            isAuthenticated = false
+            email = ""
+            password = ""
+            confirmPassword = ""
+            clearErrors()
+        }
+    }
+
     /// Resets all error fields.
     func clearErrors() {
         emailError = nil

--- a/idea-pilot/idea-pilot/Navigation/MainTabView.swift
+++ b/idea-pilot/idea-pilot/Navigation/MainTabView.swift
@@ -1,0 +1,61 @@
+//
+//  MainTabView.swift
+//  idea-pilot
+//
+//  Placeholder tab bar for the authenticated state.
+//  Real tab content will be added in future milestones.
+//
+
+import SwiftUI
+
+/// The main tab bar shown when the user is authenticated.
+///
+/// Currently contains placeholder tabs. Future milestones will replace these
+/// with real content (Now lane, Playbook list, etc.).
+struct MainTabView: View {
+
+    /// Called when the user taps sign out. Owned by RootView.
+    var onSignOut: () -> Void
+
+    var body: some View {
+        TabView {
+            Tab("Now", systemImage: "bolt.fill") {
+                placeholderTab("Now")
+            }
+
+            Tab("Playbooks", systemImage: "book.fill") {
+                placeholderTab("Playbooks")
+            }
+        }
+        .tint(Color.theme.primary)
+    }
+
+    private func placeholderTab(_ title: String) -> some View {
+        ZStack {
+            Color.theme.background
+                .ignoresSafeArea()
+
+            VStack(spacing: 24) {
+                Text(title)
+                    .font(.theme.largeTitle)
+                    .foregroundStyle(Color.theme.foreground)
+
+                Text("Coming soon")
+                    .font(.theme.subheadline)
+                    .foregroundStyle(Color.theme.mutedForeground)
+
+                Button {
+                    onSignOut()
+                } label: {
+                    Text("Sign Out")
+                        .font(.theme.body)
+                        .foregroundStyle(Color.theme.destructive)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    MainTabView(onSignOut: {})
+}

--- a/idea-pilot/idea-pilot/Navigation/RootView.swift
+++ b/idea-pilot/idea-pilot/Navigation/RootView.swift
@@ -2,41 +2,100 @@
 //  RootView.swift
 //  idea-pilot
 //
-//  Created by Harold Bostic on 2/21/26.
+//  Root navigation gate that routes based on authentication state.
+//  Unauthenticated → AuthView, Authenticated → MainTabView.
 //
 
 import SwiftUI
 
-/// The root navigation view that determines which screen the user sees.
+/// The root view that gates on authentication state.
 ///
-/// Currently displays a placeholder launch screen. Once auth is implemented (Issue #10),
-/// this view will act as the auth gate:
-/// - Authenticated → `MainTabView`
-/// - Unauthenticated → `AuthRootView`
-/// - Session expired → toast + redirect to auth
+/// On launch, checks `TokenManager.isAuthenticated`:
+/// - If tokens exist → show `MainTabView` (attempt background refresh)
+/// - If no tokens → show `AuthView`
+///
+/// Transitions are animated with a crossfade for a polished experience.
 struct RootView: View {
+
+    let tokenManager: TokenManager
+    let authService: any AuthServiceProtocol
+
+    @State private var isAuthenticated = false
+    @State private var isCheckingAuth = true
+    @State private var authViewModel: AuthViewModel?
+
     var body: some View {
+        Group {
+            if isCheckingAuth {
+                splashView
+            } else if isAuthenticated {
+                MainTabView(onSignOut: signOut)
+            } else if let vm = authViewModel {
+                AuthView(vm: vm)
+            }
+        }
+        .animation(.easeInOut(duration: 0.3), value: isAuthenticated)
+        .animation(.easeInOut(duration: 0.3), value: isCheckingAuth)
+        .task { await checkAuthState() }
+        .onChange(of: authViewModel?.isAuthenticated) { _, newValue in
+            if newValue == true {
+                isAuthenticated = true
+            }
+        }
+    }
+
+    // MARK: - Splash (shown briefly during auth check)
+
+    private var splashView: some View {
         ZStack {
             Color.theme.background
                 .ignoresSafeArea()
 
             VStack(spacing: 16) {
-                Image(systemName: "airplane")
-                    .font(.system(size: 64))
-                    .foregroundStyle(Color.theme.foreground)
+                Image(systemName: "play.fill")
+                    .font(.system(size: 36))
+                    .foregroundStyle(.white)
+                    .frame(width: 72, height: 72)
+                    .background(Color.theme.primary)
+                    .clipShape(RoundedRectangle(cornerRadius: .theme.radiusLg))
+                    .shadow(color: Color.theme.primary.opacity(0.5), radius: 20, y: 4)
 
                 Text("Idea Pilot")
                     .font(.theme.largeTitle)
                     .foregroundStyle(Color.theme.foreground)
-
-                Text("Helping you land on the tarmac of execution")
-                    .font(.theme.subheadline)
-                    .foregroundStyle(Color.theme.mutedForeground)
             }
         }
     }
-}
 
-#Preview {
-    RootView()
+    // MARK: - Auth State
+
+    private func checkAuthState() async {
+        let authenticated = await tokenManager.isAuthenticated
+        if authenticated {
+            isAuthenticated = true
+            isCheckingAuth = false
+            // Attempt background token refresh for returning users.
+            Task {
+                try? await tokenManager.refresh()
+            }
+        } else {
+            authViewModel = AuthViewModel(authService: authService)
+            isCheckingAuth = false
+        }
+    }
+
+    private func signOut() {
+        guard let vm = authViewModel else {
+            // Create a fresh ViewModel for the auth screen.
+            let newVM = AuthViewModel(authService: authService)
+            authViewModel = newVM
+            Task {
+                try? await authService.logout()
+            }
+            isAuthenticated = false
+            return
+        }
+        vm.signOut()
+        isAuthenticated = false
+    }
 }


### PR DESCRIPTION
## Summary
- `RootView` now gates on `TokenManager.isAuthenticated` — auth screen or main tab view
- Brief splash during Keychain check prevents auth screen flash for returning users
- Smooth crossfade transition between authenticated/unauthenticated states
- Full dependency graph bootstrapped in `idea_pilotApp.init()`: ModelContainer → TokenManager → APIClient → AuthService
- `MainTabView` placeholder with "Now" and "Playbooks" tabs + temporary sign-out button
- Added `signOut()` method to `AuthViewModel` for logout flow
- Background token refresh attempted for returning users with cached tokens

## Test plan
- [x] Build succeeds — zero errors, zero warnings
- [x] All 96 unit tests still pass
- [ ] CI passes on GitHub Actions
- [ ] Manual test: launch → auth screen → sign in → tab view → sign out → auth screen

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)