### PR TITLE
feat: custom 3-tab bar with glass effect

### DIFF
--- a/idea-pilot/idea-pilot/Navigation/MainTabView.swift
+++ b/idea-pilot/idea-pilot/Navigation/MainTabView.swift
@@ -2,41 +2,182 @@
 //  MainTabView.swift
 //  idea-pilot
 //
-//  Placeholder tab bar for the authenticated state.
-//  Real tab content will be added in future milestones.
+//  Custom 3-tab bottom bar: Now, Capture (sheet), Playbooks.
+//  Uses a glass-effect custom tab bar instead of the system TabView.
 //
 
 import SwiftUI
 
+// MARK: - Tab Model
+
+/// The selectable tabs in the main tab bar.
+///
+/// Capture is not included because it opens a sheet overlay
+/// rather than switching the active tab.
+enum AppTab: Int, CaseIterable {
+    case now
+    case playbooks
+
+    var label: String {
+        switch self {
+        case .now: "Now"
+        case .playbooks: "Playbooks"
+        }
+    }
+
+    var activeIcon: String {
+        switch self {
+        case .now: "play.fill"
+        case .playbooks: "square.stack.fill"
+        }
+    }
+
+    var inactiveIcon: String {
+        switch self {
+        case .now: "play"
+        case .playbooks: "square.stack"
+        }
+    }
+}
+
+// MARK: - MainTabView
+
 /// The main tab bar shown when the user is authenticated.
 ///
-/// Currently contains placeholder tabs. Future milestones will replace these
-/// with real content (Now lane, Playbook list, etc.).
+/// Features a custom glass-effect tab bar with three items:
+/// - **Now** — Playbook home (left)
+/// - **Capture** — Opens a sheet overlay (center, larger purple icon)
+/// - **Playbooks** — Playbook list (right)
+///
+/// Both Now and Playbooks maintain their own `NavigationStack` so
+/// navigation state is preserved when switching tabs.
 struct MainTabView: View {
 
     /// Called when the user taps sign out. Owned by RootView.
     var onSignOut: () -> Void
 
-    var body: some View {
-        TabView {
-            Tab("Now", systemImage: "bolt.fill") {
-                placeholderTab("Now")
-            }
+    @State private var selectedTab: AppTab = .now
+    @State private var showCaptureSheet = false
 
-            Tab("Playbooks", systemImage: "book.fill") {
-                placeholderTab("Playbooks")
-            }
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            // Tab content — both always present to preserve NavigationStack state.
+            tabContent
+
+            // Custom glass tab bar overlay.
+            CustomTabBar(
+                selectedTab: $selectedTab,
+                onCaptureTap: { showCaptureSheet = true }
+            )
         }
-        .tint(Color.theme.primary)
+        .themeBackground()
+        .sheet(isPresented: $showCaptureSheet) {
+            CapturePlaceholderView()
+        }
     }
 
-    private func placeholderTab(_ title: String) -> some View {
+    // MARK: - Tab Content
+
+    @ViewBuilder
+    private var tabContent: some View {
+        ZStack {
+            NavigationStack {
+                NowPlaceholderView(onSignOut: onSignOut)
+            }
+            .opacity(selectedTab == .now ? 1 : 0)
+
+            NavigationStack {
+                PlaybooksPlaceholderView()
+            }
+            .opacity(selectedTab == .playbooks ? 1 : 0)
+        }
+    }
+}
+
+// MARK: - Custom Tab Bar
+
+/// A glass-effect bottom tab bar with Now, Capture, and Playbooks buttons.
+///
+/// The center capture button has a distinct raised purple circle style.
+/// Active tabs show filled icons with labels; inactive tabs show outline icons only.
+private struct CustomTabBar: View {
+
+    @Binding var selectedTab: AppTab
+    var onCaptureTap: () -> Void
+
+    var body: some View {
+        HStack {
+            tabButton(.now)
+
+            Spacer()
+
+            captureButton
+
+            Spacer()
+
+            tabButton(.playbooks)
+        }
+        .padding(.horizontal, 32)
+        .padding(.top, 12)
+        .padding(.bottom, 4)
+        .glassStyle()
+    }
+
+    // MARK: - Regular Tab Button
+
+    private func tabButton(_ tab: AppTab) -> some View {
+        Button {
+            selectedTab = tab
+        } label: {
+            VStack(spacing: 4) {
+                Image(systemName: selectedTab == tab ? tab.activeIcon : tab.inactiveIcon)
+                    .font(.system(size: 22))
+
+                if selectedTab == tab {
+                    Text(tab.label)
+                        .font(.theme.caption)
+                }
+            }
+            .foregroundStyle(selectedTab == tab ? Color.theme.primary : Color.theme.mutedForeground)
+            .frame(minWidth: 56, minHeight: 44)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Capture Button (Center)
+
+    private var captureButton: some View {
+        Button {
+            onCaptureTap()
+        } label: {
+            Image(systemName: "plus")
+                .font(.system(size: 22, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 48, height: 48)
+                .background(Color.theme.primary)
+                .clipShape(Circle())
+                .shadow(color: Color.theme.primary.opacity(0.4), radius: 8, y: 2)
+        }
+        .buttonStyle(.plain)
+        .offset(y: -8)
+    }
+}
+
+// MARK: - Placeholder Tab Views
+
+/// Placeholder for the Now tab content.
+private struct NowPlaceholderView: View {
+
+    var onSignOut: () -> Void
+
+    var body: some View {
         ZStack {
             Color.theme.background
                 .ignoresSafeArea()
 
             VStack(spacing: 24) {
-                Text(title)
+                Text("Now")
                     .font(.theme.largeTitle)
                     .foregroundStyle(Color.theme.foreground)
 
@@ -53,8 +194,71 @@ struct MainTabView: View {
                 }
             }
         }
+        .safeAreaPadding(.bottom, 72)
     }
 }
+
+/// Placeholder for the Playbooks tab content.
+private struct PlaybooksPlaceholderView: View {
+
+    var body: some View {
+        ZStack {
+            Color.theme.background
+                .ignoresSafeArea()
+
+            VStack(spacing: 24) {
+                Text("Playbooks")
+                    .font(.theme.largeTitle)
+                    .foregroundStyle(Color.theme.foreground)
+
+                Text("Coming soon")
+                    .font(.theme.subheadline)
+                    .foregroundStyle(Color.theme.mutedForeground)
+            }
+        }
+        .safeAreaPadding(.bottom, 72)
+    }
+}
+
+/// Placeholder for the Capture sheet overlay.
+private struct CapturePlaceholderView: View {
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.theme.background
+                    .ignoresSafeArea()
+
+                VStack(spacing: 24) {
+                    Image(systemName: "plus.circle.fill")
+                        .font(.system(size: 48))
+                        .foregroundStyle(Color.theme.primary)
+
+                    Text("Capture")
+                        .font(.theme.largeTitle)
+                        .foregroundStyle(Color.theme.foreground)
+
+                    Text("Quick capture coming soon")
+                        .font(.theme.subheadline)
+                        .foregroundStyle(Color.theme.mutedForeground)
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                        .foregroundStyle(Color.theme.primary)
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+        .presentationBackground(Color.theme.background)
+    }
+}
+
+// MARK: - Preview
 
 #Preview {
     MainTabView(onSignOut: {})


### PR DESCRIPTION
## Summary
- Replaced placeholder `TabView` with custom glass-effect tab bar matching the design spec
- 3 tabs: **Now** (play.fill), **Capture** (plus circle, sheet overlay), **Playbooks** (square.stack.fill)
- Active tab shows filled icon + label in primary color; inactive shows outline icon in muted
- Center capture button has raised purple circle design, opens a half-sheet overlay
- Each tab maintains its own `NavigationStack` for state preservation
- Uses existing `.glassStyle()` modifier for the tab bar background

## Test plan
- [x] `xcodebuild build` — zero errors
- [x] All 98 unit tests pass
- [ ] Run on simulator: verify tab switching, capture sheet, sign-out flow
- [ ] Verify glass effect renders correctly over content

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)