### PR TITLE
feat: PlaybookService — fetch, create, archive playbooks

### DIFF
--- a/idea-pilot/idea-pilot/Core/Networking/Endpoint.swift
+++ b/idea-pilot/idea-pilot/Core/Networking/Endpoint.swift
@@ -77,8 +77,12 @@ extension Endpoint {
 
 extension Endpoint {
 
-    static func getPlaybooks() -> Endpoint {
-        Endpoint(path: "/v1/playbooks", method: .get)
+    static func getPlaybooks(updatedSince: Date? = nil) -> Endpoint {
+        var queryItems: [URLQueryItem]?
+        if let date = updatedSince {
+            queryItems = [URLQueryItem(name: "updated_since", value: ISO8601DateFormatter().string(from: date))]
+        }
+        return Endpoint(path: "/v1/playbooks", method: .get, queryItems: queryItems)
     }
 
     static func getPlaybook(id: String) -> Endpoint {
@@ -95,6 +99,10 @@ extension Endpoint {
 
     static func deletePlaybook(id: String) -> Endpoint {
         Endpoint(path: "/v1/playbooks/\(id)", method: .delete)
+    }
+
+    static func archivePlaybook(id: String) -> Endpoint {
+        Endpoint(path: "/v1/playbooks/\(id)/archive", method: .post)
     }
 }
 

--- a/idea-pilot/idea-pilot/Features/Playbooks/Services/PlaybookService.swift
+++ b/idea-pilot/idea-pilot/Features/Playbooks/Services/PlaybookService.swift
@@ -1,0 +1,207 @@
+//
+//  PlaybookService.swift
+//  idea-pilot
+//
+//  Service handling playbook API calls and SwiftData persistence.
+//  Supports fetch (with incremental sync), create, and archive operations.
+//
+
+import Foundation
+import SwiftData
+
+// MARK: - PlaybookError
+
+/// Errors specific to playbook operations.
+nonisolated enum PlaybookError: Error, Equatable, Sendable {
+    /// The requested playbook was not found (404).
+    case notFound
+    /// A network-level failure occurred.
+    case networkError(String)
+    /// The server returned an unexpected error.
+    case serverError(String)
+}
+
+// MARK: - PlaybookServiceProtocol
+
+/// Defines the playbook API surface for testability.
+nonisolated protocol PlaybookServiceProtocol: Sendable {
+    /// Fetches playbooks from the API, upserts into SwiftData, and returns the models.
+    /// Falls back to cached SwiftData data when offline.
+    func fetchPlaybooks(updatedSince: Date?) async throws -> [PlaybookModel]
+
+    /// Creates a new playbook on the server and inserts it into SwiftData.
+    func createPlaybook(title: String, description: String?) async throws -> PlaybookModel
+
+    /// Archives a playbook on the server and updates SwiftData.
+    func archivePlaybook(id: String) async throws
+}
+
+// MARK: - PlaybookService
+
+/// Coordinates playbook CRUD through `APIClient` and SwiftData.
+///
+/// Each operation follows the pattern:
+/// 1. Call the API endpoint
+/// 2. Upsert/update SwiftData
+/// 3. Return the model(s)
+///
+/// `fetchPlaybooks` supports offline fallback by reading from SwiftData cache
+/// when the network is unavailable.
+final class PlaybookService: PlaybookServiceProtocol, Sendable {
+
+    private let apiClient: APIClient
+    private let modelContainer: ModelContainer
+
+    /// Creates a PlaybookService.
+    ///
+    /// - Parameters:
+    ///   - apiClient: The networking client for API calls.
+    ///   - modelContainer: The SwiftData container for local persistence.
+    init(apiClient: APIClient, modelContainer: ModelContainer) {
+        self.apiClient = apiClient
+        self.modelContainer = modelContainer
+    }
+
+    func fetchPlaybooks(updatedSince: Date? = nil) async throws -> [PlaybookModel] {
+        do {
+            let dtos: [PlaybookDTO] = try await apiClient.request(.getPlaybooks(updatedSince: updatedSince))
+            return try await upsertPlaybooks(dtos)
+        } catch let error as APIError {
+            if error.isOffline {
+                return try await cachedPlaybooks()
+            }
+            throw mapError(error)
+        } catch let error as PlaybookError {
+            throw error
+        } catch {
+            throw PlaybookError.serverError(error.localizedDescription)
+        }
+    }
+
+    func createPlaybook(title: String, description: String?) async throws -> PlaybookModel {
+        let dto = CreatePlaybookDTO(title: title, description: description, phase: PlaybookPhase.proof.rawValue)
+        do {
+            let response: PlaybookDTO = try await apiClient.request(.createPlaybook(dto: dto))
+            return try await insertPlaybook(response)
+        } catch let error as APIError {
+            throw mapError(error)
+        } catch let error as PlaybookError {
+            throw error
+        } catch {
+            throw PlaybookError.serverError(error.localizedDescription)
+        }
+    }
+
+    func archivePlaybook(id: String) async throws {
+        do {
+            try await apiClient.requestVoid(.archivePlaybook(id: id))
+            try await markArchived(id: id)
+        } catch let error as APIError {
+            throw mapError(error)
+        } catch let error as PlaybookError {
+            throw error
+        } catch {
+            throw PlaybookError.serverError(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Private — SwiftData Operations
+
+    /// Upserts an array of playbook DTOs into SwiftData.
+    @MainActor
+    private func upsertPlaybooks(_ dtos: [PlaybookDTO]) throws -> [PlaybookModel] {
+        let context = modelContainer.mainContext
+        var models: [PlaybookModel] = []
+
+        for dto in dtos {
+            let predicate = #Predicate<PlaybookModel> { $0.id == dto.id }
+            var descriptor = FetchDescriptor(predicate: predicate)
+            descriptor.fetchLimit = 1
+
+            if let existing = try context.fetch(descriptor).first {
+                // Update existing model.
+                existing.title = dto.title
+                existing.descriptionText = dto.description
+                existing.phaseRawValue = dto.phase
+                existing.isArchived = dto.isArchived
+                existing.updatedAt = dto.updatedAt
+                models.append(existing)
+            } else {
+                // Insert new model.
+                let model = dto.toModel()
+                context.insert(model)
+                models.append(model)
+            }
+        }
+
+        try context.save()
+        return models
+    }
+
+    /// Inserts a single playbook DTO into SwiftData.
+    @MainActor
+    private func insertPlaybook(_ dto: PlaybookDTO) throws -> PlaybookModel {
+        let context = modelContainer.mainContext
+        let model = dto.toModel()
+        context.insert(model)
+        try context.save()
+        return model
+    }
+
+    /// Marks a playbook as archived in SwiftData.
+    @MainActor
+    private func markArchived(id: String) throws {
+        let context = modelContainer.mainContext
+        let predicate = #Predicate<PlaybookModel> { $0.id == id }
+        var descriptor = FetchDescriptor(predicate: predicate)
+        descriptor.fetchLimit = 1
+
+        guard let model = try context.fetch(descriptor).first else { return }
+        model.isArchived = true
+        try context.save()
+    }
+
+    /// Returns cached non-archived playbooks from SwiftData (offline fallback).
+    @MainActor
+    private func cachedPlaybooks() throws -> [PlaybookModel] {
+        let context = modelContainer.mainContext
+        let predicate = #Predicate<PlaybookModel> { $0.isArchived == false }
+        let descriptor = FetchDescriptor(predicate: predicate, sortBy: [SortDescriptor(\.updatedAt, order: .reverse)])
+        return try context.fetch(descriptor)
+    }
+
+    // MARK: - Private — Error Mapping
+
+    private func mapError(_ error: APIError) -> PlaybookError {
+        switch error {
+        case .notFound:
+            return .notFound
+        case .networkError(let urlError):
+            return .networkError(urlError.localizedDescription)
+        case .offline:
+            return .networkError("No internet connection")
+        case .serverError(_, let message):
+            return .serverError(message ?? "Server error")
+        case .badRequest(let message):
+            return .serverError(message ?? "Bad request")
+        case .sessionExpired:
+            return .serverError("Session expired")
+        case .decodingError(let message):
+            return .serverError("Invalid response: \(message)")
+        }
+    }
+}
+
+// MARK: - APIError Offline Helper
+
+extension APIError {
+
+    /// Whether this error represents an offline/network condition.
+    var isOffline: Bool {
+        switch self {
+        case .offline: return true
+        case .networkError: return true
+        default: return false
+        }
+    }
+}

--- a/idea-pilot/idea-pilotTests/PlaybookServiceTests.swift
+++ b/idea-pilot/idea-pilotTests/PlaybookServiceTests.swift
@@ -1,0 +1,349 @@
+//
+//  PlaybookServiceTests.swift
+//  idea-pilotTests
+//
+//  Unit tests for PlaybookService with mock networking and in-memory SwiftData.
+//
+
+import Foundation
+import SwiftData
+import Testing
+@testable import idea_pilot
+
+// MARK: - Mock URL Protocol (independent from other test suites)
+
+/// A `URLProtocol` subclass for PlaybookService tests, independent of other mocks.
+final class PlaybookServiceMockURLProtocol: URLProtocol, @unchecked Sendable {
+
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> (Data, HTTPURLResponse))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = PlaybookServiceMockURLProtocol.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+
+        do {
+            let (data, response) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Test Helpers
+
+private let testBaseURL = URL(string: "https://api.test.ideapilot.app")!
+
+private func makeURLSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [PlaybookServiceMockURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+private nonisolated func makeResponse(statusCode: Int) -> HTTPURLResponse {
+    HTTPURLResponse(
+        url: testBaseURL,
+        statusCode: statusCode,
+        httpVersion: nil,
+        headerFields: nil
+    )!
+}
+
+private nonisolated func makeInMemoryModelContainer() throws -> ModelContainer {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    return try ModelContainer(
+        for: PlaybookModel.self, TaskModel.self, SectionModel.self, WeeklyCycleModel.self,
+        configurations: config
+    )
+}
+
+private nonisolated func makePlaybookService(
+    session: URLSession? = nil
+) throws -> (PlaybookService, ModelContainer) {
+    let urlSession = session ?? makeURLSession()
+    let apiClient = APIClient(baseURL: testBaseURL, session: urlSession)
+    let container = try makeInMemoryModelContainer()
+    let service = PlaybookService(apiClient: apiClient, modelContainer: container)
+    return (service, container)
+}
+
+// MARK: - Mock JSON Fixtures
+
+private let singlePlaybookJSON = #"""
+{
+    "id": "pb-1",
+    "title": "Test Playbook",
+    "description": "A test playbook",
+    "phase": "PROOF",
+    "is_archived": false,
+    "created_at": "2025-01-01T00:00:00Z",
+    "updated_at": "2025-01-02T00:00:00Z"
+}
+"""#
+
+private let playbooksArrayJSON = #"""
+[
+    {
+        "id": "pb-1",
+        "title": "Playbook One",
+        "description": "First playbook",
+        "phase": "PROOF",
+        "is_archived": false,
+        "created_at": "2025-01-01T00:00:00Z",
+        "updated_at": "2025-01-02T00:00:00Z"
+    },
+    {
+        "id": "pb-2",
+        "title": "Playbook Two",
+        "description": null,
+        "phase": "STRUCTURE",
+        "is_archived": false,
+        "created_at": "2025-01-03T00:00:00Z",
+        "updated_at": "2025-01-04T00:00:00Z"
+    }
+]
+"""#
+
+private let updatedPlaybookJSON = #"""
+[
+    {
+        "id": "pb-1",
+        "title": "Updated Title",
+        "description": "Updated description",
+        "phase": "STRUCTURE",
+        "is_archived": false,
+        "created_at": "2025-01-01T00:00:00Z",
+        "updated_at": "2025-01-10T00:00:00Z"
+    }
+]
+"""#
+
+// MARK: - PlaybookService Tests
+
+@Suite("PlaybookService", .serialized)
+struct PlaybookServiceTests {
+
+    // MARK: - Fetch
+
+    @Test("fetchPlaybooks decodes array and upserts into SwiftData")
+    func fetchPlaybooksSuccess() async throws {
+        PlaybookServiceMockURLProtocol.handler = { _ in
+            (Data(playbooksArrayJSON.utf8), makeResponse(statusCode: 200))
+        }
+
+        let (service, container) = try makePlaybookService()
+        let models = try await service.fetchPlaybooks(updatedSince: nil)
+
+        #expect(models.count == 2)
+        #expect(models.contains { $0.id == "pb-1" && $0.title == "Playbook One" })
+        #expect(models.contains { $0.id == "pb-2" && $0.title == "Playbook Two" })
+
+        // Verify SwiftData persistence.
+        let context = await container.mainContext
+        let descriptor = FetchDescriptor<PlaybookModel>()
+        let persisted = try await context.fetch(descriptor)
+        #expect(persisted.count == 2)
+
+        PlaybookServiceMockURLProtocol.handler = nil
+    }
+
+    @Test("fetchPlaybooks upserts existing models instead of duplicating")
+    func fetchPlaybooksUpserts() async throws {
+        let (service, container) = try makePlaybookService()
+
+        // First fetch — inserts.
+        PlaybookServiceMockURLProtocol.handler = { _ in
+            (Data(playbooksArrayJSON.utf8), makeResponse(statusCode: 200))
+        }
+        _ = try await service.fetchPlaybooks(updatedSince: nil)
+
+        // Second fetch — same IDs, updated data.
+        PlaybookServiceMockURLProtocol.handler = { _ in
+            (Data(updatedPlaybookJSON.utf8), makeResponse(statusCode: 200))
+        }
+        let models = try await service.fetchPlaybooks(updatedSince: nil)
+
+        #expect(models.count == 1)
+        #expect(models.first?.title == "Updated Title")
+        #expect(models.first?.phase == .structure)
+
+        // Verify no duplicates — should still have 2 total (pb-1 updated + pb-2 unchanged).
+        let context = await container.mainContext
+        let descriptor = FetchDescriptor<PlaybookModel>()
+        let persisted = try await context.fetch(descriptor)
+        #expect(persisted.count == 2)
+
+        PlaybookServiceMockURLProtocol.handler = nil
+    }
+
+    @Test("fetchPlaybooks falls back to SwiftData cache when offline")
+    func fetchPlaybooksOfflineFallback() async throws {
+        let (service, container) = try makePlaybookService()
+
+        // Seed SwiftData with a cached playbook.
+        let context = await container.mainContext
+        let cached = PlaybookModel(id: "pb-cached", title: "Cached Playbook")
+        await context.insert(cached)
+        try await context.save()
+
+        // Simulate offline.
+        PlaybookServiceMockURLProtocol.handler = { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+
+        let models = try await service.fetchPlaybooks(updatedSince: nil)
+
+        #expect(models.count == 1)
+        #expect(models.first?.title == "Cached Playbook")
+
+        PlaybookServiceMockURLProtocol.handler = nil
+    }
+
+    @Test("fetchPlaybooks sends updated_since query parameter")
+    func fetchPlaybooksWithUpdatedSince() async throws {
+        nonisolated(unsafe) var capturedURL: URL?
+
+        PlaybookServiceMockURLProtocol.handler = { request in
+            capturedURL = request.url
+            return (Data("[]".utf8), makeResponse(statusCode: 200))
+        }
+
+        let (service, _) = try makePlaybookService()
+        let date = ISO8601DateFormatter().date(from: "2025-06-01T00:00:00Z")!
+        _ = try await service.fetchPlaybooks(updatedSince: date)
+
+        #expect(capturedURL?.absoluteString.contains("updated_since=") == true)
+
+        PlaybookServiceMockURLProtocol.handler = nil
+    }
+
+    @Test("fetchPlaybooks server error throws PlaybookError.serverError")
+    func fetchPlaybooksServerError() async throws {
+        let errorJSON = #"{"message":"Internal server error"}"#
+        PlaybookServiceMockURLProtocol.handler = { _ in
+            (Data(errorJSON.utf8), makeResponse(statusCode: 500))
+        }
+
+        let (service, _) = try makePlaybookService()
+
+        do {
+            _ = try await service.fetchPlaybooks(updatedSince: nil)
+            Issue.record("Expected PlaybookError.serverError")
+        } catch let error as PlaybookError {
+            guard case .serverError = error else {
+                Issue.record("Expected serverError, got \(error)")
+                return
+            }
+        }
+
+        PlaybookServiceMockURLProtocol.handler = nil
+    }
+
+    // MARK: - Create
+
+    @Test("createPlaybook creates via API and inserts into SwiftData")
+    func createPlaybookSuccess() async throws {
+        PlaybookServiceMockURLProtocol.handler = { _ in
+            (Data(singlePlaybookJSON.utf8), makeResponse(statusCode: 201))
+        }
+
+        let (service, container) = try makePlaybookService()
+        let model = try await service.createPlaybook(title: "Test Playbook", description: "A test playbook")
+
+        #expect(model.id == "pb-1")
+        #expect(model.title == "Test Playbook")
+        #expect(model.phase == .proof)
+
+        // Verify SwiftData persistence.
+        let context = await container.mainContext
+        let descriptor = FetchDescriptor<PlaybookModel>()
+        let persisted = try await context.fetch(descriptor)
+        #expect(persisted.count == 1)
+
+        PlaybookServiceMockURLProtocol.handler = nil
+    }
+
+    @Test("createPlaybook network error throws PlaybookError.networkError")
+    func createPlaybookNetworkError() async throws {
+        PlaybookServiceMockURLProtocol.handler = { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+
+        let (service, _) = try makePlaybookService()
+
+        do {
+            _ = try await service.createPlaybook(title: "Test", description: nil)
+            Issue.record("Expected PlaybookError.networkError")
+        } catch let error as PlaybookError {
+            guard case .networkError = error else {
+                Issue.record("Expected networkError, got \(error)")
+                return
+            }
+        }
+
+        PlaybookServiceMockURLProtocol.handler = nil
+    }
+
+    // MARK: - Archive
+
+    @Test("archivePlaybook calls endpoint and updates SwiftData")
+    func archivePlaybookSuccess() async throws {
+        let (service, container) = try makePlaybookService()
+
+        // Seed SwiftData with a playbook.
+        let context = await container.mainContext
+        let playbook = PlaybookModel(id: "pb-1", title: "To Archive")
+        await context.insert(playbook)
+        try await context.save()
+
+        nonisolated(unsafe) var capturedPath: String?
+        nonisolated(unsafe) var capturedMethod: String?
+
+        PlaybookServiceMockURLProtocol.handler = { request in
+            capturedPath = request.url?.path
+            capturedMethod = request.httpMethod
+            return (Data(), makeResponse(statusCode: 200))
+        }
+
+        try await service.archivePlaybook(id: "pb-1")
+
+        #expect(capturedPath?.contains("/v1/playbooks/pb-1/archive") == true)
+        #expect(capturedMethod == "POST")
+
+        // Verify SwiftData update.
+        let predicate = #Predicate<PlaybookModel> { $0.id == "pb-1" }
+        var descriptor = FetchDescriptor(predicate: predicate)
+        descriptor.fetchLimit = 1
+        let updated = try await context.fetch(descriptor).first
+        #expect(updated?.isArchived == true)
+
+        PlaybookServiceMockURLProtocol.handler = nil
+    }
+
+    @Test("archivePlaybook 404 throws PlaybookError.notFound")
+    func archivePlaybookNotFound() async throws {
+        PlaybookServiceMockURLProtocol.handler = { _ in
+            (Data(), makeResponse(statusCode: 404))
+        }
+
+        let (service, _) = try makePlaybookService()
+
+        do {
+            try await service.archivePlaybook(id: "nonexistent")
+            Issue.record("Expected PlaybookError.notFound")
+        } catch let error as PlaybookError {
+            #expect(error == .notFound)
+        }
+
+        PlaybookServiceMockURLProtocol.handler = nil
+    }
+}


### PR DESCRIPTION
## Summary
- Added `PlaybookService` with `PlaybookServiceProtocol` following established AuthService pattern
- `fetchPlaybooks(updatedSince:)` — fetches from API, upserts into SwiftData, falls back to cache offline
- `createPlaybook(title:description:)` — creates remotely, inserts into SwiftData
- `archivePlaybook(id:)` — POSTs to archive endpoint, updates local SwiftData
- `PlaybookError` enum with `notFound`, `networkError`, `serverError` cases
- Added `archivePlaybook` endpoint and `updatedSince` query param support to `Endpoint`
- 9 unit tests with dedicated mock URLProtocol and in-memory SwiftData

## Test plan
- [x] `xcodebuild build` — zero errors
- [x] All 107 tests pass (98 existing + 9 new PlaybookService tests)
- [x] Fetch, upsert, offline fallback, create, archive, and error paths all covered

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)