### PR TITLE
fix: align PlaybookDTO with backend archivedAt and wire + to create

### DIFF
--- a/idea-pilot/idea-pilot/Core/Networking/DTOs/PlaybookDTO.swift
+++ b/idea-pilot/idea-pilot/Core/Networking/DTOs/PlaybookDTO.swift
@@ -13,7 +13,7 @@ nonisolated struct PlaybookDTO: Codable, Sendable {
     let title: String
     let description: String?
     let phase: String
-    let isArchived: Bool
+    let archivedAt: Date?
     let createdAt: Date
     let updatedAt: Date
     let tasks: [TaskDTO]?
@@ -47,7 +47,7 @@ extension PlaybookDTO {
             title: title,
             descriptionText: description,
             phase: PlaybookPhase(rawValue: phase) ?? .proof,
-            isArchived: isArchived,
+            isArchived: archivedAt != nil,
             createdAt: createdAt,
             updatedAt: updatedAt
         )

--- a/idea-pilot/idea-pilot/Features/Playbooks/Services/PlaybookService.swift
+++ b/idea-pilot/idea-pilot/Features/Playbooks/Services/PlaybookService.swift
@@ -123,7 +123,7 @@ final class PlaybookService: PlaybookServiceProtocol, Sendable {
                 existing.title = dto.title
                 existing.descriptionText = dto.description
                 existing.phaseRawValue = dto.phase
-                existing.isArchived = dto.isArchived
+                existing.isArchived = dto.archivedAt != nil
                 existing.updatedAt = dto.updatedAt
                 models.append(existing)
             } else {

--- a/idea-pilot/idea-pilot/Navigation/MainTabView.swift
+++ b/idea-pilot/idea-pilot/Navigation/MainTabView.swift
@@ -2,7 +2,7 @@
 //  MainTabView.swift
 //  idea-pilot
 //
-//  Custom 3-tab bottom bar: Now, Capture (sheet), Playbooks.
+//  Custom 3-tab bottom bar: Now, Create (+), Playbooks.
 //  Uses a glass-effect custom tab bar instead of the system TabView.
 //
 
@@ -46,7 +46,7 @@ enum AppTab: Int, CaseIterable {
 ///
 /// Features a custom glass-effect tab bar with three items:
 /// - **Now** — Playbook home (left)
-/// - **Capture** — Opens a sheet overlay (center, larger purple icon)
+/// - **Create (+)** — Opens the Create Playbook sheet (center, larger purple icon)
 /// - **Playbooks** — Playbook list (right)
 ///
 /// Both Now and Playbooks maintain their own `NavigationStack` so
@@ -57,7 +57,6 @@ struct MainTabView: View {
     var onSignOut: () -> Void
 
     @State private var selectedTab: AppTab = .now
-    @State private var showCaptureSheet = false
     @State private var playbookListVM: PlaybookListViewModel
 
     init(playbookService: any PlaybookServiceProtocol, onSignOut: @escaping () -> Void) {
@@ -73,13 +72,10 @@ struct MainTabView: View {
             // Custom glass tab bar overlay.
             CustomTabBar(
                 selectedTab: $selectedTab,
-                onCaptureTap: { showCaptureSheet = true }
+                onCaptureTap: { playbookListVM.showCreateSheet = true }
             )
         }
         .themeBackground()
-        .sheet(isPresented: $showCaptureSheet) {
-            CapturePlaceholderView()
-        }
     }
 
     // MARK: - Tab Content
@@ -201,44 +197,6 @@ private struct NowPlaceholderView: View {
             }
         }
         .safeAreaPadding(.bottom, 72)
-    }
-}
-
-/// Placeholder for the Capture sheet overlay.
-private struct CapturePlaceholderView: View {
-
-    @Environment(\.dismiss) private var dismiss
-
-    var body: some View {
-        NavigationStack {
-            ZStack {
-                Color.theme.background
-                    .ignoresSafeArea()
-
-                VStack(spacing: 24) {
-                    Image(systemName: "plus.circle.fill")
-                        .font(.system(size: 48))
-                        .foregroundStyle(Color.theme.primary)
-
-                    Text("Capture")
-                        .font(.theme.largeTitle)
-                        .foregroundStyle(Color.theme.foreground)
-
-                    Text("Quick capture coming soon")
-                        .font(.theme.subheadline)
-                        .foregroundStyle(Color.theme.mutedForeground)
-                }
-            }
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button("Done") { dismiss() }
-                        .foregroundStyle(Color.theme.primary)
-                }
-            }
-        }
-        .presentationDetents([.medium, .large])
-        .presentationDragIndicator(.visible)
-        .presentationBackground(Color.theme.background)
     }
 }
 

--- a/idea-pilot/idea-pilotTests/APIClientTests.swift
+++ b/idea-pilot/idea-pilotTests/APIClientTests.swift
@@ -415,7 +415,7 @@ struct DTOTests {
             "title": "My Playbook",
             "description": null,
             "phase": "PROOF",
-            "is_archived": false,
+            "archived_at": null,
             "created_at": "2026-01-01T00:00:00Z",
             "updated_at": "2026-01-01T00:00:00Z",
             "tasks": null,
@@ -430,7 +430,7 @@ struct DTOTests {
         #expect(dto.id == "pb-1")
         #expect(dto.title == "My Playbook")
         #expect(dto.phase == "PROOF")
-        #expect(dto.isArchived == false)
+        #expect(dto.archivedAt == nil)
     }
 
     @Test("TaskDTO Codable roundtrip with snake_case")

--- a/idea-pilot/idea-pilotTests/PlaybookServiceTests.swift
+++ b/idea-pilot/idea-pilotTests/PlaybookServiceTests.swift
@@ -84,7 +84,7 @@ private let singlePlaybookJSON = #"""
     "title": "Test Playbook",
     "description": "A test playbook",
     "phase": "PROOF",
-    "is_archived": false,
+    "archived_at": null,
     "created_at": "2025-01-01T00:00:00Z",
     "updated_at": "2025-01-02T00:00:00Z"
 }
@@ -97,7 +97,7 @@ private let playbooksArrayJSON = #"""
         "title": "Playbook One",
         "description": "First playbook",
         "phase": "PROOF",
-        "is_archived": false,
+        "archived_at": null,
         "created_at": "2025-01-01T00:00:00Z",
         "updated_at": "2025-01-02T00:00:00Z"
     },
@@ -106,7 +106,7 @@ private let playbooksArrayJSON = #"""
         "title": "Playbook Two",
         "description": null,
         "phase": "STRUCTURE",
-        "is_archived": false,
+        "archived_at": null,
         "created_at": "2025-01-03T00:00:00Z",
         "updated_at": "2025-01-04T00:00:00Z"
     }
@@ -120,7 +120,7 @@ private let updatedPlaybookJSON = #"""
         "title": "Updated Title",
         "description": "Updated description",
         "phase": "STRUCTURE",
-        "is_archived": false,
+        "archived_at": null,
         "created_at": "2025-01-01T00:00:00Z",
         "updated_at": "2025-01-10T00:00:00Z"
     }


### PR DESCRIPTION
## Summary
- Fixed `PlaybookDTO` decoding: backend returns `archivedAt` (nullable date) not `isArchived` (bool), causing "Something went wrong" on create despite 201
- Wired center "+" tab bar button to open Create Playbook sheet instead of unimplemented Capture placeholder
- Removed `CapturePlaceholderView`

## Test plan
- [x] Build succeeds locally
- [ ] CI passes
- [ ] Manual: create playbook via "+" → sheet appears, playbook created and listed
- [ ] Manual: existing playbooks display correctly on launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)