### PR TITLE
feat: TaskService — CRUD, complete, reorder with optimistic create

### DIFF
--- a/idea-pilot/idea-pilot/Core/Networking/Endpoint.swift
+++ b/idea-pilot/idea-pilot/Core/Networking/Endpoint.swift
@@ -110,8 +110,19 @@ extension Endpoint {
 
 extension Endpoint {
 
-    static func getTasks(playbookId: String) -> Endpoint {
-        Endpoint(path: "/v1/playbooks/\(playbookId)/tasks", method: .get)
+    static func getTasks(playbookId: String, lane: String? = nil, updatedSince: Date? = nil) -> Endpoint {
+        var queryItems: [URLQueryItem] = []
+        if let lane {
+            queryItems.append(URLQueryItem(name: "lane", value: lane))
+        }
+        if let date = updatedSince {
+            queryItems.append(URLQueryItem(name: "updated_since", value: ISO8601DateFormatter().string(from: date)))
+        }
+        return Endpoint(
+            path: "/v1/playbooks/\(playbookId)/tasks",
+            method: .get,
+            queryItems: queryItems.isEmpty ? nil : queryItems
+        )
     }
 
     static func createTask(dto: CreateTaskDTO) -> Endpoint {
@@ -120,6 +131,10 @@ extension Endpoint {
 
     static func updateTask(id: String, dto: UpdateTaskDTO) -> Endpoint {
         Endpoint(path: "/v1/tasks/\(id)", method: .patch, body: dto)
+    }
+
+    static func completeTask(id: String) -> Endpoint {
+        Endpoint(path: "/v1/tasks/\(id)/complete", method: .post)
     }
 
     static func deleteTask(id: String) -> Endpoint {

--- a/idea-pilot/idea-pilot/Features/Tasks/Services/TaskService.swift
+++ b/idea-pilot/idea-pilot/Features/Tasks/Services/TaskService.swift
@@ -1,0 +1,394 @@
+//
+//  TaskService.swift
+//  idea-pilot
+//
+//  Service handling task API calls and SwiftData persistence.
+//  Supports fetch (with incremental sync), create (optimistic), update,
+//  complete (optimistic), reorder, and delete operations.
+//
+
+import Foundation
+import SwiftData
+
+// MARK: - TaskError
+
+/// Errors specific to task operations.
+nonisolated enum TaskError: Error, Equatable, Sendable {
+    /// The requested task was not found (404).
+    case notFound
+    /// A network-level failure occurred.
+    case networkError(String)
+    /// The server returned an unexpected error.
+    case serverError(String)
+}
+
+// MARK: - TaskServiceProtocol
+
+/// Defines the task API surface for testability.
+nonisolated protocol TaskServiceProtocol: Sendable {
+    /// Fetches tasks from the API, upserts into SwiftData, and returns the models.
+    /// Falls back to cached SwiftData data when offline.
+    func fetchTasks(playbookId: String, lane: TaskLane?, updatedSince: Date?) async throws -> [TaskModel]
+
+    /// Creates a new task optimistically (inserts locally first, then syncs with API).
+    func createTask(playbookId: String, title: String, detail: String?, lane: TaskLane, estimatedMinutes: Int) async throws -> TaskModel
+
+    /// Updates task fields on the server and in SwiftData.
+    func updateTask(id: String, dto: UpdateTaskDTO) async throws -> TaskModel
+
+    /// Marks a task as done (optimistic — updates locally, then syncs).
+    func completeTask(id: String) async throws -> TaskModel
+
+    /// Sends a full ordered ID list to reorder tasks within a lane.
+    func reorderTasks(playbookId: String, lane: TaskLane, taskIds: [String]) async throws
+
+    /// Deletes a task on the server and removes it from SwiftData.
+    func deleteTask(id: String) async throws
+}
+
+// MARK: - TaskService
+
+/// Coordinates task CRUD through `APIClient` and SwiftData.
+///
+/// Each operation follows one of two patterns:
+/// - **Standard**: Call the API → update SwiftData → return model(s)
+/// - **Optimistic**: Update SwiftData → call the API → reconcile on success / rollback on failure
+///
+/// `fetchTasks` supports offline fallback by reading from SwiftData cache
+/// when the network is unavailable.
+final class TaskService: TaskServiceProtocol, Sendable {
+
+    private let apiClient: APIClient
+    private let modelContainer: ModelContainer
+
+    /// Creates a TaskService.
+    ///
+    /// - Parameters:
+    ///   - apiClient: The networking client for API calls.
+    ///   - modelContainer: The SwiftData container for local persistence.
+    init(apiClient: APIClient, modelContainer: ModelContainer) {
+        self.apiClient = apiClient
+        self.modelContainer = modelContainer
+    }
+
+    func fetchTasks(playbookId: String, lane: TaskLane? = nil, updatedSince: Date? = nil) async throws -> [TaskModel] {
+        do {
+            let dtos: [TaskDTO] = try await apiClient.request(
+                .getTasks(playbookId: playbookId, lane: lane?.rawValue, updatedSince: updatedSince)
+            )
+            return try await upsertTasks(dtos)
+        } catch let error as APIError {
+            if error.isOffline {
+                return try await cachedTasks(playbookId: playbookId, lane: lane)
+            }
+            throw mapError(error)
+        } catch let error as TaskError {
+            throw error
+        } catch {
+            throw TaskError.serverError(error.localizedDescription)
+        }
+    }
+
+    func createTask(
+        playbookId: String,
+        title: String,
+        detail: String?,
+        lane: TaskLane,
+        estimatedMinutes: Int
+    ) async throws -> TaskModel {
+        // 1. Insert optimistically with a temp ID.
+        let tempId = try await insertOptimisticTask(
+            playbookId: playbookId,
+            title: title,
+            detail: detail,
+            lane: lane,
+            estimatedMinutes: estimatedMinutes
+        )
+
+        // 2. Call API.
+        let dto = CreateTaskDTO(
+            playbookId: playbookId,
+            title: title,
+            detail: detail,
+            lane: lane.rawValue,
+            estimatedMinutes: estimatedMinutes
+        )
+
+        do {
+            let response: TaskDTO = try await apiClient.request(.createTask(dto: dto))
+            // 3. On success: reconcile local model with server response.
+            return try await reconcileCreatedTask(tempId: tempId, dto: response)
+        } catch {
+            // 4. On failure: rollback (delete the optimistic insert).
+            try await rollbackTask(tempId: tempId)
+            if let apiError = error as? APIError {
+                throw mapError(apiError)
+            }
+            throw TaskError.serverError(error.localizedDescription)
+        }
+    }
+
+    func updateTask(id: String, dto: UpdateTaskDTO) async throws -> TaskModel {
+        do {
+            let response: TaskDTO = try await apiClient.request(.updateTask(id: id, dto: dto))
+            return try await upsertSingleTask(response)
+        } catch let error as APIError {
+            throw mapError(error)
+        } catch let error as TaskError {
+            throw error
+        } catch {
+            throw TaskError.serverError(error.localizedDescription)
+        }
+    }
+
+    func completeTask(id: String) async throws -> TaskModel {
+        // Optimistically mark done locally.
+        let previousState = try await markTaskDone(id: id)
+
+        do {
+            let response: TaskDTO = try await apiClient.request(.completeTask(id: id))
+            // Reconcile with server response (server sets canonical completedAt).
+            return try await upsertSingleTask(response)
+        } catch {
+            // Rollback on failure.
+            try await restoreTaskState(id: id, previousState: previousState)
+            if let apiError = error as? APIError {
+                throw mapError(apiError)
+            }
+            throw TaskError.serverError(error.localizedDescription)
+        }
+    }
+
+    func reorderTasks(playbookId: String, lane: TaskLane, taskIds: [String]) async throws {
+        let dto = ReorderTasksDTO(playbookId: playbookId, lane: lane.rawValue, taskIds: taskIds)
+        do {
+            try await apiClient.requestVoid(.reorderTasks(dto: dto))
+            try await updateLocalOrder(taskIds: taskIds)
+        } catch let error as APIError {
+            throw mapError(error)
+        } catch let error as TaskError {
+            throw error
+        } catch {
+            throw TaskError.serverError(error.localizedDescription)
+        }
+    }
+
+    func deleteTask(id: String) async throws {
+        do {
+            try await apiClient.requestVoid(.deleteTask(id: id))
+            try await removeTask(id: id)
+        } catch let error as APIError {
+            throw mapError(error)
+        } catch let error as TaskError {
+            throw error
+        } catch {
+            throw TaskError.serverError(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Private — SwiftData Operations
+
+    /// Upserts an array of task DTOs into SwiftData.
+    @MainActor
+    private func upsertTasks(_ dtos: [TaskDTO]) throws -> [TaskModel] {
+        let context = modelContainer.mainContext
+        var models: [TaskModel] = []
+
+        for dto in dtos {
+            let predicate = #Predicate<TaskModel> { $0.id == dto.id }
+            var descriptor = FetchDescriptor(predicate: predicate)
+            descriptor.fetchLimit = 1
+
+            if let existing = try context.fetch(descriptor).first {
+                existing.title = dto.title
+                existing.detail = dto.detail
+                existing.laneRawValue = dto.lane
+                existing.estimatedMinutes = dto.estimatedMinutes
+                existing.statusRawValue = dto.status
+                existing.orderIndex = dto.orderIndex
+                existing.completedAt = dto.completedAt
+                existing.updatedAt = dto.updatedAt
+                models.append(existing)
+            } else {
+                let model = dto.toModel()
+                context.insert(model)
+                models.append(model)
+            }
+        }
+
+        try context.save()
+        return models
+    }
+
+    /// Upserts a single task DTO into SwiftData.
+    @MainActor
+    private func upsertSingleTask(_ dto: TaskDTO) throws -> TaskModel {
+        try upsertTasks([dto]).first!
+    }
+
+    /// Inserts a task model optimistically with a temporary ID. Returns the temp ID.
+    @MainActor
+    private func insertOptimisticTask(
+        playbookId: String,
+        title: String,
+        detail: String?,
+        lane: TaskLane,
+        estimatedMinutes: Int
+    ) throws -> String {
+        let context = modelContainer.mainContext
+        let model = TaskModel(
+            playbookId: playbookId,
+            title: title,
+            detail: detail,
+            lane: lane,
+            estimatedMinutes: estimatedMinutes
+        )
+        context.insert(model)
+        try context.save()
+        return model.id
+    }
+
+    /// Replaces the optimistic model with the server-truth model.
+    @MainActor
+    private func reconcileCreatedTask(tempId: String, dto: TaskDTO) throws -> TaskModel {
+        let context = modelContainer.mainContext
+
+        // Delete the temp model.
+        let predicate = #Predicate<TaskModel> { $0.id == tempId }
+        var descriptor = FetchDescriptor(predicate: predicate)
+        descriptor.fetchLimit = 1
+        if let temp = try context.fetch(descriptor).first {
+            context.delete(temp)
+        }
+
+        // Insert the server-truth model.
+        let model = dto.toModel()
+        context.insert(model)
+        try context.save()
+        return model
+    }
+
+    /// Deletes the optimistic model on API failure.
+    @MainActor
+    private func rollbackTask(tempId: String) throws {
+        let context = modelContainer.mainContext
+        let predicate = #Predicate<TaskModel> { $0.id == tempId }
+        var descriptor = FetchDescriptor(predicate: predicate)
+        descriptor.fetchLimit = 1
+        if let temp = try context.fetch(descriptor).first {
+            context.delete(temp)
+            try context.save()
+        }
+    }
+
+    /// Marks a task as done and returns its previous state for rollback.
+    @MainActor
+    private func markTaskDone(id: String) throws -> TaskPreviousState {
+        let context = modelContainer.mainContext
+        let predicate = #Predicate<TaskModel> { $0.id == id }
+        var descriptor = FetchDescriptor(predicate: predicate)
+        descriptor.fetchLimit = 1
+
+        guard let model = try context.fetch(descriptor).first else {
+            throw TaskError.notFound
+        }
+
+        let previous = TaskPreviousState(
+            statusRawValue: model.statusRawValue,
+            completedAt: model.completedAt
+        )
+
+        model.status = .done
+        model.completedAt = .now
+        try context.save()
+
+        return previous
+    }
+
+    /// Restores a task to its previous state after a failed API call.
+    @MainActor
+    private func restoreTaskState(id: String, previousState: TaskPreviousState) throws {
+        let context = modelContainer.mainContext
+        let predicate = #Predicate<TaskModel> { $0.id == id }
+        var descriptor = FetchDescriptor(predicate: predicate)
+        descriptor.fetchLimit = 1
+
+        guard let model = try context.fetch(descriptor).first else { return }
+        model.statusRawValue = previousState.statusRawValue
+        model.completedAt = previousState.completedAt
+        try context.save()
+    }
+
+    /// Updates local orderIndex values after a successful reorder.
+    @MainActor
+    private func updateLocalOrder(taskIds: [String]) throws {
+        let context = modelContainer.mainContext
+
+        for (index, taskId) in taskIds.enumerated() {
+            let predicate = #Predicate<TaskModel> { $0.id == taskId }
+            var descriptor = FetchDescriptor(predicate: predicate)
+            descriptor.fetchLimit = 1
+            if let model = try context.fetch(descriptor).first {
+                model.orderIndex = index
+            }
+        }
+
+        try context.save()
+    }
+
+    /// Removes a task from SwiftData.
+    @MainActor
+    private func removeTask(id: String) throws {
+        let context = modelContainer.mainContext
+        let predicate = #Predicate<TaskModel> { $0.id == id }
+        var descriptor = FetchDescriptor(predicate: predicate)
+        descriptor.fetchLimit = 1
+
+        guard let model = try context.fetch(descriptor).first else { return }
+        context.delete(model)
+        try context.save()
+    }
+
+    /// Returns cached tasks from SwiftData (offline fallback).
+    @MainActor
+    private func cachedTasks(playbookId: String, lane: TaskLane?) throws -> [TaskModel] {
+        let context = modelContainer.mainContext
+        let predicate: Predicate<TaskModel>
+        if let laneRaw = lane?.rawValue {
+            predicate = #Predicate<TaskModel> { $0.playbookId == playbookId && $0.laneRawValue == laneRaw }
+        } else {
+            predicate = #Predicate<TaskModel> { $0.playbookId == playbookId }
+        }
+        let descriptor = FetchDescriptor(predicate: predicate, sortBy: [SortDescriptor(\.orderIndex)])
+        return try context.fetch(descriptor)
+    }
+
+    // MARK: - Private — Error Mapping
+
+    private func mapError(_ error: APIError) -> TaskError {
+        switch error {
+        case .notFound:
+            return .notFound
+        case .networkError(let urlError):
+            return .networkError(urlError.localizedDescription)
+        case .offline:
+            return .networkError("No internet connection")
+        case .serverError(_, let message):
+            return .serverError(message ?? "Server error")
+        case .badRequest(let message):
+            return .serverError(message ?? "Bad request")
+        case .sessionExpired:
+            return .serverError("Session expired")
+        case .decodingError(let message):
+            return .serverError("Invalid response: \(message)")
+        }
+    }
+}
+
+// MARK: - TaskPreviousState
+
+/// Captures task state before an optimistic mutation for potential rollback.
+private struct TaskPreviousState {
+    let statusRawValue: String
+    let completedAt: Date?
+}

--- a/idea-pilot/idea-pilotTests/TaskServiceTests.swift
+++ b/idea-pilot/idea-pilotTests/TaskServiceTests.swift
@@ -1,0 +1,559 @@
+//
+//  TaskServiceTests.swift
+//  idea-pilotTests
+//
+//  Unit tests for TaskService with mock networking and in-memory SwiftData.
+//
+
+import Foundation
+import SwiftData
+import Testing
+@testable import idea_pilot
+
+// MARK: - Mock URL Protocol (independent from other test suites)
+
+/// A `URLProtocol` subclass for TaskService tests, independent of other mocks.
+final class TaskServiceMockURLProtocol: URLProtocol, @unchecked Sendable {
+
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> (Data, HTTPURLResponse))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = TaskServiceMockURLProtocol.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+
+        do {
+            let (data, response) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Test Helpers
+
+private let testBaseURL = URL(string: "https://api.test.ideapilot.app")!
+
+private func makeURLSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [TaskServiceMockURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+private nonisolated func makeResponse(statusCode: Int) -> HTTPURLResponse {
+    HTTPURLResponse(
+        url: testBaseURL,
+        statusCode: statusCode,
+        httpVersion: nil,
+        headerFields: nil
+    )!
+}
+
+private nonisolated func makeInMemoryModelContainer() throws -> ModelContainer {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    return try ModelContainer(
+        for: PlaybookModel.self, TaskModel.self, SectionModel.self, WeeklyCycleModel.self,
+        configurations: config
+    )
+}
+
+private nonisolated func makeTaskService(
+    session: URLSession? = nil
+) throws -> (TaskService, ModelContainer) {
+    let urlSession = session ?? makeURLSession()
+    let apiClient = APIClient(baseURL: testBaseURL, session: urlSession)
+    let container = try makeInMemoryModelContainer()
+    let service = TaskService(apiClient: apiClient, modelContainer: container)
+    return (service, container)
+}
+
+// MARK: - Mock JSON Fixtures
+
+private let singleTaskJSON = #"""
+{
+    "id": "task-1",
+    "playbook_id": "pb-1",
+    "title": "Write tests",
+    "detail": "Unit tests for TaskService",
+    "lane": "NOW",
+    "estimated_minutes": 90,
+    "status": "OPEN",
+    "order_index": 0,
+    "completed_at": null,
+    "created_at": "2025-01-01T00:00:00Z",
+    "updated_at": "2025-01-02T00:00:00Z"
+}
+"""#
+
+private let tasksArrayJSON = #"""
+[
+    {
+        "id": "task-1",
+        "playbook_id": "pb-1",
+        "title": "Task One",
+        "detail": null,
+        "lane": "NOW",
+        "estimated_minutes": 60,
+        "status": "OPEN",
+        "order_index": 0,
+        "completed_at": null,
+        "created_at": "2025-01-01T00:00:00Z",
+        "updated_at": "2025-01-02T00:00:00Z"
+    },
+    {
+        "id": "task-2",
+        "playbook_id": "pb-1",
+        "title": "Task Two",
+        "detail": "Some detail",
+        "lane": "NEXT",
+        "estimated_minutes": 120,
+        "status": "OPEN",
+        "order_index": 1,
+        "completed_at": null,
+        "created_at": "2025-01-03T00:00:00Z",
+        "updated_at": "2025-01-04T00:00:00Z"
+    }
+]
+"""#
+
+private let updatedTasksJSON = #"""
+[
+    {
+        "id": "task-1",
+        "playbook_id": "pb-1",
+        "title": "Updated Title",
+        "detail": "Updated detail",
+        "lane": "NEXT",
+        "estimated_minutes": 120,
+        "status": "OPEN",
+        "order_index": 0,
+        "completed_at": null,
+        "created_at": "2025-01-01T00:00:00Z",
+        "updated_at": "2025-01-10T00:00:00Z"
+    }
+]
+"""#
+
+private let completedTaskJSON = #"""
+{
+    "id": "task-1",
+    "playbook_id": "pb-1",
+    "title": "Task One",
+    "detail": null,
+    "lane": "NOW",
+    "estimated_minutes": 60,
+    "status": "DONE",
+    "order_index": 0,
+    "completed_at": "2025-01-05T12:00:00Z",
+    "created_at": "2025-01-01T00:00:00Z",
+    "updated_at": "2025-01-05T12:00:00Z"
+}
+"""#
+
+private let updatedSingleTaskJSON = #"""
+{
+    "id": "task-1",
+    "playbook_id": "pb-1",
+    "title": "Patched Title",
+    "detail": "Patched detail",
+    "lane": "LATER",
+    "estimated_minutes": 45,
+    "status": "OPEN",
+    "order_index": 0,
+    "completed_at": null,
+    "created_at": "2025-01-01T00:00:00Z",
+    "updated_at": "2025-01-10T00:00:00Z"
+}
+"""#
+
+// MARK: - TaskService Tests
+
+@Suite("TaskService", .serialized)
+struct TaskServiceTests {
+
+    // MARK: - Fetch
+
+    @Test("fetchTasks decodes array and upserts into SwiftData")
+    func fetchTasksSuccess() async throws {
+        TaskServiceMockURLProtocol.handler = { _ in
+            (Data(tasksArrayJSON.utf8), makeResponse(statusCode: 200))
+        }
+
+        let (service, container) = try makeTaskService()
+        let models = try await service.fetchTasks(playbookId: "pb-1", lane: nil, updatedSince: nil)
+
+        #expect(models.count == 2)
+        #expect(models.contains { $0.id == "task-1" && $0.title == "Task One" })
+        #expect(models.contains { $0.id == "task-2" && $0.title == "Task Two" })
+
+        // Verify SwiftData persistence.
+        let context = await container.mainContext
+        let descriptor = FetchDescriptor<TaskModel>()
+        let persisted = try await context.fetch(descriptor)
+        #expect(persisted.count == 2)
+
+        TaskServiceMockURLProtocol.handler = nil
+    }
+
+    @Test("fetchTasks upserts existing models instead of duplicating")
+    func fetchTasksUpserts() async throws {
+        let (service, container) = try makeTaskService()
+
+        // First fetch — inserts.
+        TaskServiceMockURLProtocol.handler = { _ in
+            (Data(tasksArrayJSON.utf8), makeResponse(statusCode: 200))
+        }
+        _ = try await service.fetchTasks(playbookId: "pb-1", lane: nil, updatedSince: nil)
+
+        // Second fetch — same IDs, updated data.
+        TaskServiceMockURLProtocol.handler = { _ in
+            (Data(updatedTasksJSON.utf8), makeResponse(statusCode: 200))
+        }
+        let models = try await service.fetchTasks(playbookId: "pb-1", lane: nil, updatedSince: nil)
+
+        #expect(models.count == 1)
+        #expect(models.first?.title == "Updated Title")
+        #expect(models.first?.lane == .next)
+
+        // Verify no duplicates — should still have 2 total (task-1 updated + task-2 unchanged).
+        let context = await container.mainContext
+        let descriptor = FetchDescriptor<TaskModel>()
+        let persisted = try await context.fetch(descriptor)
+        #expect(persisted.count == 2)
+
+        TaskServiceMockURLProtocol.handler = nil
+    }
+
+    @Test("fetchTasks falls back to SwiftData cache when offline")
+    func fetchTasksOfflineFallback() async throws {
+        let (service, container) = try makeTaskService()
+
+        // Seed SwiftData with a cached task.
+        let context = await container.mainContext
+        let cached = TaskModel(playbookId: "pb-1", title: "Cached Task", lane: .now)
+        await context.insert(cached)
+        try await context.save()
+
+        // Simulate offline.
+        TaskServiceMockURLProtocol.handler = { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+
+        let models = try await service.fetchTasks(playbookId: "pb-1", lane: nil, updatedSince: nil)
+
+        #expect(models.count == 1)
+        #expect(models.first?.title == "Cached Task")
+
+        TaskServiceMockURLProtocol.handler = nil
+    }
+
+    @Test("fetchTasks sends lane and updated_since query parameters")
+    func fetchTasksWithLaneAndUpdatedSince() async throws {
+        nonisolated(unsafe) var capturedURL: URL?
+
+        TaskServiceMockURLProtocol.handler = { request in
+            capturedURL = request.url
+            return (Data("[]".utf8), makeResponse(statusCode: 200))
+        }
+
+        let (service, _) = try makeTaskService()
+        let date = ISO8601DateFormatter().date(from: "2025-06-01T00:00:00Z")!
+        _ = try await service.fetchTasks(playbookId: "pb-1", lane: .now, updatedSince: date)
+
+        let urlString = capturedURL?.absoluteString ?? ""
+        #expect(urlString.contains("lane=NOW"))
+        #expect(urlString.contains("updated_since="))
+
+        TaskServiceMockURLProtocol.handler = nil
+    }
+
+    @Test("fetchTasks server error throws TaskError.serverError")
+    func fetchTasksServerError() async throws {
+        let errorJSON = #"{"message":"Internal server error"}"#
+        TaskServiceMockURLProtocol.handler = { _ in
+            (Data(errorJSON.utf8), makeResponse(statusCode: 500))
+        }
+
+        let (service, _) = try makeTaskService()
+
+        do {
+            _ = try await service.fetchTasks(playbookId: "pb-1", lane: nil, updatedSince: nil)
+            Issue.record("Expected TaskError.serverError")
+        } catch let error as TaskError {
+            guard case .serverError = error else {
+                Issue.record("Expected serverError, got \(error)")
+                return
+            }
+        }
+
+        TaskServiceMockURLProtocol.handler = nil
+    }
+
+    // MARK: - Create (Optimistic)
+
+    @Test("createTask creates via API and inserts into SwiftData with server ID")
+    func createTaskSuccess() async throws {
+        TaskServiceMockURLProtocol.handler = { _ in
+            (Data(singleTaskJSON.utf8), makeResponse(statusCode: 201))
+        }
+
+        let (service, container) = try makeTaskService()
+        let model = try await service.createTask(
+            playbookId: "pb-1",
+            title: "Write tests",
+            detail: "Unit tests for TaskService",
+            lane: .now,
+            estimatedMinutes: 90
+        )
+
+        #expect(model.id == "task-1")
+        #expect(model.title == "Write tests")
+        #expect(model.lane == .now)
+        #expect(model.estimatedMinutes == 90)
+
+        // Verify SwiftData has exactly 1 record with the server ID (temp removed).
+        let context = await container.mainContext
+        let descriptor = FetchDescriptor<TaskModel>()
+        let persisted = try await context.fetch(descriptor)
+        #expect(persisted.count == 1)
+        #expect(persisted.first?.id == "task-1")
+
+        TaskServiceMockURLProtocol.handler = nil
+    }
+
+    @Test("createTask rolls back optimistic insert on network failure")
+    func createTaskOptimisticRollback() async throws {
+        TaskServiceMockURLProtocol.handler = { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+
+        let (service, container) = try makeTaskService()
+
+        do {
+            _ = try await service.createTask(
+                playbookId: "pb-1",
+                title: "Should rollback",
+                detail: nil,
+                lane: .now,
+                estimatedMinutes: 60
+            )
+            Issue.record("Expected TaskError.networkError")
+        } catch let error as TaskError {
+            guard case .networkError = error else {
+                Issue.record("Expected networkError, got \(error)")
+                return
+            }
+        }
+
+        // Verify SwiftData is empty (optimistic insert was rolled back).
+        let context = await container.mainContext
+        let descriptor = FetchDescriptor<TaskModel>()
+        let persisted = try await context.fetch(descriptor)
+        #expect(persisted.count == 0)
+
+        TaskServiceMockURLProtocol.handler = nil
+    }
+
+    @Test("createTask network error throws TaskError.networkError")
+    func createTaskNetworkError() async throws {
+        TaskServiceMockURLProtocol.handler = { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+
+        let (service, _) = try makeTaskService()
+
+        do {
+            _ = try await service.createTask(
+                playbookId: "pb-1",
+                title: "Test",
+                detail: nil,
+                lane: .later,
+                estimatedMinutes: 30
+            )
+            Issue.record("Expected TaskError.networkError")
+        } catch let error as TaskError {
+            guard case .networkError = error else {
+                Issue.record("Expected networkError, got \(error)")
+                return
+            }
+        }
+
+        TaskServiceMockURLProtocol.handler = nil
+    }
+
+    // MARK: - Update
+
+    @Test("updateTask patches via API and updates SwiftData")
+    func updateTaskSuccess() async throws {
+        let (service, container) = try makeTaskService()
+
+        // Seed SwiftData with a task.
+        let context = await container.mainContext
+        let task = TaskModel(id: "task-1", playbookId: "pb-1", title: "Original Title", lane: .now)
+        await context.insert(task)
+        try await context.save()
+
+        TaskServiceMockURLProtocol.handler = { _ in
+            (Data(updatedSingleTaskJSON.utf8), makeResponse(statusCode: 200))
+        }
+
+        let dto = UpdateTaskDTO(title: "Patched Title", detail: "Patched detail", lane: "LATER", estimatedMinutes: 45, status: nil, orderIndex: nil)
+        let model = try await service.updateTask(id: "task-1", dto: dto)
+
+        #expect(model.title == "Patched Title")
+        #expect(model.detail == "Patched detail")
+        #expect(model.lane == .later)
+        #expect(model.estimatedMinutes == 45)
+
+        // Verify SwiftData reflects the update (no duplicates).
+        let descriptor = FetchDescriptor<TaskModel>()
+        let persisted = try await context.fetch(descriptor)
+        #expect(persisted.count == 1)
+        #expect(persisted.first?.title == "Patched Title")
+
+        TaskServiceMockURLProtocol.handler = nil
+    }
+
+    // MARK: - Complete (Optimistic)
+
+    @Test("completeTask marks done via API and updates SwiftData")
+    func completeTaskSuccess() async throws {
+        let (service, container) = try makeTaskService()
+
+        // Seed SwiftData with an OPEN task.
+        let context = await container.mainContext
+        let task = TaskModel(id: "task-1", playbookId: "pb-1", title: "Task One", lane: .now)
+        await context.insert(task)
+        try await context.save()
+
+        TaskServiceMockURLProtocol.handler = { _ in
+            (Data(completedTaskJSON.utf8), makeResponse(statusCode: 200))
+        }
+
+        let model = try await service.completeTask(id: "task-1")
+
+        #expect(model.status == .done)
+        #expect(model.completedAt != nil)
+
+        // Verify SwiftData reflects completion.
+        let predicate = #Predicate<TaskModel> { $0.id == "task-1" }
+        var descriptor = FetchDescriptor(predicate: predicate)
+        descriptor.fetchLimit = 1
+        let persisted = try await context.fetch(descriptor).first
+        #expect(persisted?.status == .done)
+        #expect(persisted?.completedAt != nil)
+
+        TaskServiceMockURLProtocol.handler = nil
+    }
+
+    @Test("completeTask rolls back to OPEN on server failure")
+    func completeTaskRollbackOnFailure() async throws {
+        let (service, container) = try makeTaskService()
+
+        // Seed SwiftData with an OPEN task.
+        let context = await container.mainContext
+        let task = TaskModel(id: "task-1", playbookId: "pb-1", title: "Task One", lane: .now)
+        await context.insert(task)
+        try await context.save()
+
+        let errorJSON = #"{"message":"Internal server error"}"#
+        TaskServiceMockURLProtocol.handler = { _ in
+            (Data(errorJSON.utf8), makeResponse(statusCode: 500))
+        }
+
+        do {
+            _ = try await service.completeTask(id: "task-1")
+            Issue.record("Expected TaskError.serverError")
+        } catch let error as TaskError {
+            guard case .serverError = error else {
+                Issue.record("Expected serverError, got \(error)")
+                return
+            }
+        }
+
+        // Verify SwiftData task is still OPEN (rolled back).
+        let predicate = #Predicate<TaskModel> { $0.id == "task-1" }
+        var descriptor = FetchDescriptor(predicate: predicate)
+        descriptor.fetchLimit = 1
+        let persisted = try await context.fetch(descriptor).first
+        #expect(persisted?.status == .open)
+        #expect(persisted?.completedAt == nil)
+
+        TaskServiceMockURLProtocol.handler = nil
+    }
+
+    // MARK: - Reorder
+
+    @Test("reorderTasks sends correct path and method")
+    func reorderTasksSuccess() async throws {
+        nonisolated(unsafe) var capturedPath: String?
+        nonisolated(unsafe) var capturedMethod: String?
+
+        TaskServiceMockURLProtocol.handler = { request in
+            capturedPath = request.url?.path
+            capturedMethod = request.httpMethod
+            return (Data(), makeResponse(statusCode: 204))
+        }
+
+        let (service, _) = try makeTaskService()
+        try await service.reorderTasks(playbookId: "pb-1", lane: .now, taskIds: ["task-2", "task-1"])
+
+        #expect(capturedPath?.contains("/v1/tasks/reorder") == true)
+        #expect(capturedMethod == "POST")
+
+        TaskServiceMockURLProtocol.handler = nil
+    }
+
+    // MARK: - Delete
+
+    @Test("deleteTask removes from SwiftData on success")
+    func deleteTaskSuccess() async throws {
+        let (service, container) = try makeTaskService()
+
+        // Seed SwiftData with a task.
+        let context = await container.mainContext
+        let task = TaskModel(id: "task-1", playbookId: "pb-1", title: "To Delete", lane: .now)
+        await context.insert(task)
+        try await context.save()
+
+        TaskServiceMockURLProtocol.handler = { _ in
+            (Data(), makeResponse(statusCode: 204))
+        }
+
+        try await service.deleteTask(id: "task-1")
+
+        // Verify the task is removed from SwiftData.
+        let descriptor = FetchDescriptor<TaskModel>()
+        let persisted = try await context.fetch(descriptor)
+        #expect(persisted.count == 0)
+
+        TaskServiceMockURLProtocol.handler = nil
+    }
+
+    @Test("deleteTask 404 throws TaskError.notFound")
+    func deleteTaskNotFound() async throws {
+        TaskServiceMockURLProtocol.handler = { _ in
+            (Data(), makeResponse(statusCode: 404))
+        }
+
+        let (service, _) = try makeTaskService()
+
+        do {
+            try await service.deleteTask(id: "nonexistent")
+            Issue.record("Expected TaskError.notFound")
+        } catch let error as TaskError {
+            #expect(error == .notFound)
+        }
+
+        TaskServiceMockURLProtocol.handler = nil
+    }
+}


### PR DESCRIPTION
## Summary
- Add `TaskService` with six operations: fetch (with incremental sync + offline fallback), create (optimistic insert with rollback), update, complete (optimistic with rollback), reorder, and delete
- Update `Endpoint.swift` with `completeTask(id:)` endpoint and `lane`/`updatedSince` query params on `getTasks`
- Add 14 unit tests covering all operations, error mapping, and optimistic rollback scenarios

Closes #17

## Test plan
- [x] `xcodebuild build` — zero errors
- [x] All 14 new `TaskServiceTests` pass
- [x] All existing tests continue to pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)