### PR TITLE
feat: Task Detail half-sheet with inline editing (#23)

### DIFF
--- a/idea-pilot/idea-pilot/Features/Tasks/ViewModels/PlaybookHomeViewModel.swift
+++ b/idea-pilot/idea-pilot/Features/Tasks/ViewModels/PlaybookHomeViewModel.swift
@@ -71,7 +71,7 @@ final class PlaybookHomeViewModel {
 
     // MARK: - Dependencies
 
-    private let taskService: any TaskServiceProtocol
+    let taskService: any TaskServiceProtocol
 
     // MARK: - Init
 

--- a/idea-pilot/idea-pilot/Features/Tasks/ViewModels/TaskDetailViewModel.swift
+++ b/idea-pilot/idea-pilot/Features/Tasks/ViewModels/TaskDetailViewModel.swift
@@ -1,0 +1,218 @@
+//
+//  TaskDetailViewModel.swift
+//  idea-pilot
+//
+//  ViewModel for the Task Detail half-sheet.
+//  Manages inline editing, debounced notes saving, completion, and deletion.
+//
+
+import Foundation
+
+/// Drives the Task Detail sheet with inline editing, debounced saves, and task lifecycle actions.
+///
+/// Uses `@Observable` for modern SwiftUI data flow. Since the project uses
+/// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, this class runs on MainActor
+/// by default — safe for driving UI.
+@Observable
+final class TaskDetailViewModel {
+
+    // MARK: - Editable State
+
+    var title: String
+    var detail: String
+    var selectedLane: TaskLane
+    var estimatedMinutes: Int
+
+    // MARK: - UI State
+
+    var isSubmitting = false
+    var showDeleteConfirmation = false
+    var error: String?
+
+    // MARK: - Computed
+
+    /// Whether the task is still open.
+    var isOpen: Bool { task.status == .open }
+
+    /// Display label for the task status.
+    var statusLabel: String { task.status.rawValue }
+
+    /// Whether the estimate exceeds the recommended maximum.
+    var showEstimateWarning: Bool { estimatedMinutes > 180 }
+
+    // MARK: - Dependencies
+
+    let task: TaskModel
+    private let taskService: any TaskServiceProtocol
+    private let onComplete: (String) -> Void
+    private let onDelete: (String) -> Void
+
+    /// Tracks the debounced detail-save task so it can be cancelled on new input.
+    private var detailSaveTask: Task<Void, Never>?
+
+    // MARK: - Init
+
+    /// Creates a TaskDetailViewModel.
+    ///
+    /// - Parameters:
+    ///   - task: The task to view/edit (shared reference type).
+    ///   - taskService: The service for task API calls.
+    ///   - onComplete: Called with the task ID after successful completion.
+    ///   - onDelete: Called with the task ID after successful deletion.
+    init(
+        task: TaskModel,
+        taskService: any TaskServiceProtocol,
+        onComplete: @escaping (String) -> Void,
+        onDelete: @escaping (String) -> Void
+    ) {
+        self.task = task
+        self.taskService = taskService
+        self.onComplete = onComplete
+        self.onDelete = onDelete
+
+        // Initialize editable state from task.
+        self.title = task.title
+        self.detail = task.detail ?? ""
+        self.selectedLane = task.lane
+        self.estimatedMinutes = task.estimatedMinutes
+    }
+
+    // MARK: - Actions
+
+    /// Saves the title to the server. Called on field commit.
+    func saveTitle() {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            // Revert to current task title if empty.
+            title = task.title
+            return
+        }
+
+        task.title = trimmed
+        title = trimmed
+
+        Task {
+            do {
+                let dto = UpdateTaskDTO(title: trimmed, detail: nil, lane: nil, estimatedMinutes: nil, status: nil, orderIndex: nil)
+                _ = try await taskService.updateTask(id: task.id, dto: dto)
+            } catch let error as TaskError {
+                mapError(error)
+            } catch {
+                self.error = "Failed to save title."
+            }
+        }
+    }
+
+    /// Saves a lane change immediately. Called when selection changes.
+    func saveLane(_ lane: TaskLane) {
+        selectedLane = lane
+        task.lane = lane
+
+        Task {
+            do {
+                let dto = UpdateTaskDTO(title: nil, detail: nil, lane: lane.rawValue, estimatedMinutes: nil, status: nil, orderIndex: nil)
+                _ = try await taskService.updateTask(id: task.id, dto: dto)
+            } catch let error as TaskError {
+                mapError(error)
+            } catch {
+                self.error = "Failed to update lane."
+            }
+        }
+    }
+
+    /// Saves an estimate change immediately. Called when selection changes.
+    func saveEstimate(_ minutes: Int) {
+        estimatedMinutes = minutes
+        task.estimatedMinutes = minutes
+
+        Task {
+            do {
+                let dto = UpdateTaskDTO(title: nil, detail: nil, lane: nil, estimatedMinutes: minutes, status: nil, orderIndex: nil)
+                _ = try await taskService.updateTask(id: task.id, dto: dto)
+            } catch let error as TaskError {
+                mapError(error)
+            } catch {
+                self.error = "Failed to update estimate."
+            }
+        }
+    }
+
+    /// Saves the detail/notes with a 1-second debounce.
+    ///
+    /// Updates the task model immediately for responsive UI,
+    /// but delays the API call so rapid typing doesn't flood the server.
+    func saveDetail() {
+        task.detail = detail.isEmpty ? nil : detail
+
+        detailSaveTask?.cancel()
+        detailSaveTask = Task {
+            try? await Task.sleep(for: .seconds(1))
+
+            guard !Task.isCancelled else { return }
+
+            do {
+                let dto = UpdateTaskDTO(title: nil, detail: detail.isEmpty ? nil : detail, lane: nil, estimatedMinutes: nil, status: nil, orderIndex: nil)
+                _ = try await taskService.updateTask(id: task.id, dto: dto)
+            } catch let error as TaskError {
+                mapError(error)
+            } catch {
+                self.error = "Failed to save notes."
+            }
+        }
+    }
+
+    /// Marks the task as done and notifies the parent.
+    func completeTask() {
+        guard isOpen else { return }
+
+        task.status = .done
+        task.completedAt = .now
+
+        Task {
+            do {
+                _ = try await taskService.completeTask(id: task.id)
+                onComplete(task.id)
+            } catch let error as TaskError {
+                // Rollback on failure.
+                task.status = .open
+                task.completedAt = nil
+                mapError(error)
+            } catch {
+                task.status = .open
+                task.completedAt = nil
+                self.error = "Failed to complete task."
+            }
+        }
+    }
+
+    /// Deletes the task after confirmation and notifies the parent.
+    func deleteTask() {
+        isSubmitting = true
+
+        Task {
+            defer { isSubmitting = false }
+
+            do {
+                try await taskService.deleteTask(id: task.id)
+                onDelete(task.id)
+            } catch let error as TaskError {
+                mapError(error)
+            } catch {
+                self.error = "Failed to delete task."
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func mapError(_ error: TaskError) {
+        switch error {
+        case .notFound:
+            self.error = "Task not found."
+        case .networkError:
+            self.error = "Network error. Please check your connection."
+        case .serverError:
+            self.error = "Something went wrong. Please try again."
+        }
+    }
+}

--- a/idea-pilot/idea-pilot/Features/Tasks/Views/PlaybookHomeView.swift
+++ b/idea-pilot/idea-pilot/Features/Tasks/Views/PlaybookHomeView.swift
@@ -75,7 +75,20 @@ struct PlaybookHomeView: View {
             }
         }
         .sheet(item: $vm.selectedTask) { task in
-            TaskDetailPlaceholder(task: task)
+            TaskDetailSheet(
+                vm: TaskDetailViewModel(
+                    task: task,
+                    taskService: vm.taskService,
+                    onComplete: { id in
+                        vm.completeTask(id: id)
+                        vm.clearSelectedTask()
+                    },
+                    onDelete: { id in
+                        vm.allTasks.removeAll { $0.id == id }
+                        vm.clearSelectedTask()
+                    }
+                )
+            )
         }
     }
 
@@ -628,35 +641,6 @@ private struct EmptyLaneView: View {
         }
         .frame(maxWidth: .infinity)
         .accessibilityElement(children: .combine)
-    }
-}
-
-// MARK: - Task Detail Placeholder
-
-/// Placeholder for the task detail half-sheet until Issue #23 is implemented.
-private struct TaskDetailPlaceholder: View {
-
-    let task: TaskModel
-
-    var body: some View {
-        NavigationStack {
-            VStack(spacing: 16) {
-                Text(task.title)
-                    .font(.theme.title2)
-                    .foregroundStyle(Color.theme.foreground)
-
-                Text("Task detail coming soon")
-                    .font(.theme.subheadline)
-                    .foregroundStyle(Color.theme.mutedForeground)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .themeBackground()
-            .navigationTitle("Task Detail")
-            .navigationBarTitleDisplayMode(.inline)
-        }
-        .presentationDetents([.medium])
-        .presentationDragIndicator(.visible)
-        .presentationBackground(Color.theme.background)
     }
 }
 

--- a/idea-pilot/idea-pilot/Features/Tasks/Views/TaskDetailSheet.swift
+++ b/idea-pilot/idea-pilot/Features/Tasks/Views/TaskDetailSheet.swift
@@ -1,0 +1,304 @@
+//
+//  TaskDetailSheet.swift
+//  idea-pilot
+//
+//  Expandable half-sheet for viewing and editing task details.
+//  Supports inline title editing, lane/estimate changes, notes with
+//  debounced save, task completion, and deletion with confirmation.
+//
+
+import SwiftUI
+
+/// An expandable half-sheet for viewing and editing a task.
+///
+/// Features:
+/// - Status pill (OPEN blue / DONE green)
+/// - Inline editable title
+/// - Lane selector chips
+/// - Estimate chips with >180m warning
+/// - Notes textarea with debounced save
+/// - Complete and Delete actions
+struct TaskDetailSheet: View {
+
+    @Bindable var vm: TaskDetailViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    statusPill
+                    titleField
+                    laneSection
+                    estimateSection
+                    notesSection
+
+                    if let error = vm.error {
+                        Text(error)
+                            .font(.theme.caption)
+                            .foregroundStyle(Color.theme.destructive)
+                    }
+
+                    actionButtons
+                }
+                .padding(.horizontal, 24)
+                .padding(.top, 16)
+                .padding(.bottom, 24)
+            }
+            .scrollDismissesKeyboard(.interactively)
+            .navigationTitle("Task Detail")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                    .foregroundStyle(Color.theme.mutedForeground)
+                }
+            }
+            .themeBackground()
+        }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+        .presentationBackground(Color.theme.background)
+        .confirmationDialog(
+            "Delete this task?",
+            isPresented: $vm.showDeleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                vm.deleteTask()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This action cannot be undone.")
+        }
+    }
+
+    // MARK: - Status Pill
+
+    @ViewBuilder
+    private var statusPill: some View {
+        let isOpen = vm.isOpen
+        let color = isOpen ? Color.theme.primary : Color.theme.accent
+
+        Text(vm.statusLabel)
+            .font(.theme.caption)
+            .fontWeight(.semibold)
+            .foregroundStyle(color)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .background(color.opacity(0.15))
+            .clipShape(RoundedRectangle(cornerRadius: .theme.radiusSm))
+            .overlay(
+                RoundedRectangle(cornerRadius: .theme.radiusSm)
+                    .stroke(color.opacity(0.3), lineWidth: 1)
+            )
+            .accessibilityLabel("Status: \(vm.statusLabel)")
+    }
+
+    // MARK: - Title Field
+
+    @ViewBuilder
+    private var titleField: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("TITLE")
+                .font(.theme.overline)
+                .foregroundStyle(Color.theme.mutedForeground)
+                .tracking(1.0)
+
+            TextField("Task title", text: $vm.title)
+                .font(.theme.title2)
+                .foregroundStyle(Color.theme.foreground)
+                .textInputAutocapitalization(.sentences)
+                .onSubmit { vm.saveTitle() }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 14)
+                .background(Color.theme.secondary)
+                .clipShape(RoundedRectangle(cornerRadius: .theme.radiusMd))
+                .overlay(
+                    RoundedRectangle(cornerRadius: .theme.radiusMd)
+                        .stroke(Color.theme.input, lineWidth: 1)
+                )
+                .submitLabel(.done)
+                .accessibilityLabel("Task title")
+        }
+    }
+
+    // MARK: - Lane Section
+
+    @ViewBuilder
+    private var laneSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("LANE")
+                .font(.theme.overline)
+                .foregroundStyle(Color.theme.mutedForeground)
+                .tracking(1.0)
+
+            LaneChipGroup(selected: $vm.selectedLane)
+                .onChange(of: vm.selectedLane) { _, newLane in
+                    vm.saveLane(newLane)
+                }
+        }
+    }
+
+    // MARK: - Estimate Section
+
+    @ViewBuilder
+    private var estimateSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("ESTIMATE")
+                .font(.theme.overline)
+                .foregroundStyle(Color.theme.mutedForeground)
+                .tracking(1.0)
+
+            TimeEstimatePickerRow(
+                selected: $vm.estimatedMinutes,
+                options: [30, 60, 90, 120, 180]
+            )
+            .onChange(of: vm.estimatedMinutes) { _, newMinutes in
+                vm.saveEstimate(newMinutes)
+            }
+
+            if vm.showEstimateWarning {
+                Text("Tasks over 3 hours are hard to complete. Consider breaking this into smaller tasks.")
+                    .font(.theme.caption)
+                    .foregroundStyle(Color.theme.destructive)
+                    .transition(.opacity)
+            }
+        }
+    }
+
+    // MARK: - Notes Section
+
+    @ViewBuilder
+    private var notesSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("NOTES")
+                .font(.theme.overline)
+                .foregroundStyle(Color.theme.mutedForeground)
+                .tracking(1.0)
+
+            ZStack(alignment: .topLeading) {
+                TextEditor(text: $vm.detail)
+                    .font(.theme.bodyRegular)
+                    .foregroundStyle(Color.theme.foreground)
+                    .scrollContentBackground(.hidden)
+                    .frame(minHeight: 80)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+                    .onChange(of: vm.detail) { _, _ in
+                        vm.saveDetail()
+                    }
+
+                if vm.detail.isEmpty {
+                    Text("Add notes or details...")
+                        .font(.theme.bodyRegular)
+                        .foregroundStyle(Color.theme.mutedForeground)
+                        .padding(.horizontal, 17)
+                        .padding(.vertical, 18)
+                        .allowsHitTesting(false)
+                }
+            }
+            .background(Color.theme.secondary)
+            .clipShape(RoundedRectangle(cornerRadius: .theme.radiusMd))
+            .overlay(
+                RoundedRectangle(cornerRadius: .theme.radiusMd)
+                    .stroke(Color.theme.input, lineWidth: 1)
+            )
+            .accessibilityLabel("Task notes")
+        }
+    }
+
+    // MARK: - Action Buttons
+
+    @ViewBuilder
+    private var actionButtons: some View {
+        VStack(spacing: 12) {
+            if vm.isOpen {
+                completeButton
+            }
+            deleteButton
+        }
+    }
+
+    @ViewBuilder
+    private var completeButton: some View {
+        Button {
+            vm.completeTask()
+        } label: {
+            Text("Complete Task")
+                .font(.theme.body)
+                .fontWeight(.semibold)
+                .foregroundStyle(Color.theme.accentForeground)
+                .frame(maxWidth: .infinity)
+                .frame(height: 50)
+                .background(Color.theme.accent)
+                .clipShape(RoundedRectangle(cornerRadius: .theme.radiusMd))
+                .shadow(color: Color.theme.accent.opacity(0.4), radius: 12, y: 4)
+        }
+        .buttonStyle(.pressable)
+        .accessibilityLabel("Complete task")
+    }
+
+    @ViewBuilder
+    private var deleteButton: some View {
+        Button {
+            vm.showDeleteConfirmation = true
+        } label: {
+            Text("Delete Task")
+                .font(.theme.body)
+                .fontWeight(.semibold)
+                .foregroundStyle(Color.theme.destructive)
+                .frame(maxWidth: .infinity)
+                .frame(height: 50)
+                .background(Color.clear)
+                .clipShape(RoundedRectangle(cornerRadius: .theme.radiusMd))
+                .overlay(
+                    RoundedRectangle(cornerRadius: .theme.radiusMd)
+                        .stroke(Color.theme.destructive.opacity(0.5), lineWidth: 1)
+                )
+        }
+        .buttonStyle(.pressable)
+        .disabled(vm.isSubmitting)
+        .accessibilityLabel("Delete task")
+        .accessibilityHint("Shows a confirmation dialog")
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    TaskDetailSheet(
+        vm: TaskDetailViewModel(
+            task: TaskModel(
+                id: "t-1",
+                playbookId: "pb-1",
+                title: "Research competitors",
+                detail: "Look at top 5 apps in the App Store",
+                lane: .now,
+                estimatedMinutes: 90,
+                orderIndex: 0
+            ),
+            taskService: TaskDetailPreviewTaskService(),
+            onComplete: { _ in },
+            onDelete: { _ in }
+        )
+    )
+}
+
+/// A no-op task service for TaskDetailSheet previews.
+private struct TaskDetailPreviewTaskService: TaskServiceProtocol {
+    nonisolated func fetchTasks(playbookId: String, lane: TaskLane?, updatedSince: Date?) async throws -> [TaskModel] { [] }
+    nonisolated func createTask(playbookId: String, title: String, detail: String?, lane: TaskLane, estimatedMinutes: Int) async throws -> TaskModel {
+        TaskModel(playbookId: playbookId, title: title, lane: lane, estimatedMinutes: estimatedMinutes)
+    }
+    nonisolated func updateTask(id: String, dto: UpdateTaskDTO) async throws -> TaskModel {
+        TaskModel(playbookId: "pb-1", title: "Updated")
+    }
+    nonisolated func completeTask(id: String) async throws -> TaskModel {
+        TaskModel(playbookId: "pb-1", title: "Done", status: .done, completedAt: .now)
+    }
+    nonisolated func reorderTasks(playbookId: String, lane: TaskLane, taskIds: [String]) async throws {}
+    nonisolated func deleteTask(id: String) async throws {}
+}

--- a/idea-pilot/idea-pilotTests/TaskDetailViewModelTests.swift
+++ b/idea-pilot/idea-pilotTests/TaskDetailViewModelTests.swift
@@ -1,0 +1,316 @@
+//
+//  TaskDetailViewModelTests.swift
+//  idea-pilotTests
+//
+//  Unit tests for TaskDetailViewModel — editing, saving, completing, and deleting tasks.
+//
+
+import Foundation
+import Testing
+@testable import idea_pilot
+
+@Suite("TaskDetailViewModel", .serialized)
+struct TaskDetailViewModelTests {
+
+    // MARK: - Helpers
+
+    private func makeTask(
+        id: String = "t-1",
+        title: String = "Test Task",
+        detail: String? = "Some notes",
+        lane: TaskLane = .now,
+        estimatedMinutes: Int = 60,
+        status: TaskStatus = .open
+    ) -> TaskModel {
+        TaskModel(
+            id: id,
+            playbookId: "pb-1",
+            title: title,
+            detail: detail,
+            lane: lane,
+            estimatedMinutes: estimatedMinutes,
+            status: status,
+            orderIndex: 0
+        )
+    }
+
+    private func makeVM(
+        task: TaskModel? = nil,
+        mockService: MockTaskService? = nil,
+        onComplete: @escaping (String) -> Void = { _ in },
+        onDelete: @escaping (String) -> Void = { _ in }
+    ) -> (TaskDetailViewModel, MockTaskService) {
+        let service = mockService ?? MockTaskService()
+        let t = task ?? makeTask()
+        let vm = TaskDetailViewModel(
+            task: t,
+            taskService: service,
+            onComplete: onComplete,
+            onDelete: onDelete
+        )
+        return (vm, service)
+    }
+
+    // MARK: - Default State
+
+    @Test("initializes from task properties")
+    @MainActor func defaultState() {
+        let task = makeTask(title: "My Task", detail: "Notes here", lane: .next, estimatedMinutes: 90)
+        let (vm, _) = makeVM(task: task)
+
+        #expect(vm.title == "My Task")
+        #expect(vm.detail == "Notes here")
+        #expect(vm.selectedLane == .next)
+        #expect(vm.estimatedMinutes == 90)
+        #expect(vm.isOpen == true)
+        #expect(vm.statusLabel == "OPEN")
+        #expect(vm.showEstimateWarning == false)
+        #expect(vm.isSubmitting == false)
+        #expect(vm.error == nil)
+    }
+
+    @Test("initializes with empty string when task detail is nil")
+    @MainActor func defaultStateNilDetail() {
+        let task = makeTask(detail: nil)
+        let (vm, _) = makeVM(task: task)
+
+        #expect(vm.detail == "")
+    }
+
+    // MARK: - Status
+
+    @Test("statusLabel returns DONE for completed tasks")
+    @MainActor func statusLabelDone() {
+        let task = makeTask(status: .done)
+        let (vm, _) = makeVM(task: task)
+
+        #expect(vm.statusLabel == "DONE")
+        #expect(vm.isOpen == false)
+    }
+
+    // MARK: - Save Title
+
+    @Test("saveTitle updates task and calls service")
+    @MainActor func saveTitleSuccess() async throws {
+        let task = makeTask()
+        let (vm, service) = makeVM(task: task)
+        service.updateResult = .success(task)
+
+        vm.title = "Updated Title"
+        vm.saveTitle()
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(task.title == "Updated Title")
+        #expect(service.updateCallCount == 1)
+        #expect(service.capturedUpdateDTO?.title == "Updated Title")
+        #expect(vm.error == nil)
+    }
+
+    @Test("saveTitle with empty string reverts to task title")
+    @MainActor func saveTitleEmptyReverts() {
+        let task = makeTask(title: "Original")
+        let (vm, service) = makeVM(task: task)
+
+        vm.title = "   "
+        vm.saveTitle()
+
+        #expect(vm.title == "Original")
+        #expect(task.title == "Original")
+        #expect(service.updateCallCount == 0)
+    }
+
+    @Test("saveTitle trims whitespace")
+    @MainActor func saveTitleTrimsWhitespace() async throws {
+        let task = makeTask()
+        let (vm, service) = makeVM(task: task)
+        service.updateResult = .success(task)
+
+        vm.title = "  Trimmed  "
+        vm.saveTitle()
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(vm.title == "Trimmed")
+        #expect(task.title == "Trimmed")
+    }
+
+    // MARK: - Save Lane
+
+    @Test("saveLane updates task and calls service")
+    @MainActor func saveLaneSuccess() async throws {
+        let task = makeTask(lane: .now)
+        let (vm, service) = makeVM(task: task)
+        service.updateResult = .success(task)
+
+        vm.saveLane(.later)
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(vm.selectedLane == .later)
+        #expect(task.lane == .later)
+        #expect(service.updateCallCount == 1)
+        #expect(service.capturedUpdateDTO?.lane == "LATER")
+    }
+
+    // MARK: - Save Estimate
+
+    @Test("saveEstimate updates task and calls service")
+    @MainActor func saveEstimateSuccess() async throws {
+        let task = makeTask(estimatedMinutes: 60)
+        let (vm, service) = makeVM(task: task)
+        service.updateResult = .success(task)
+
+        vm.saveEstimate(120)
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(vm.estimatedMinutes == 120)
+        #expect(task.estimatedMinutes == 120)
+        #expect(service.updateCallCount == 1)
+    }
+
+    @Test("showEstimateWarning is true when estimate exceeds 180")
+    @MainActor func estimateWarning() {
+        let task = makeTask(estimatedMinutes: 60)
+        let (vm, _) = makeVM(task: task)
+
+        #expect(vm.showEstimateWarning == false)
+
+        vm.estimatedMinutes = 181
+        #expect(vm.showEstimateWarning == true)
+
+        vm.estimatedMinutes = 180
+        #expect(vm.showEstimateWarning == false)
+    }
+
+    // MARK: - Save Detail (Debounced)
+
+    @Test("saveDetail updates task model immediately but debounces API call")
+    @MainActor func saveDetailDebounce() async throws {
+        let task = makeTask(detail: nil)
+        let (vm, service) = makeVM(task: task)
+        service.updateResult = .success(task)
+
+        vm.detail = "New notes"
+        vm.saveDetail()
+
+        // Task model updated immediately.
+        #expect(task.detail == "New notes")
+
+        // API not called yet (debounce).
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(service.updateCallCount == 0)
+
+        // Wait for debounce to complete.
+        try await Task.sleep(for: .milliseconds(1100))
+        #expect(service.updateCallCount == 1)
+    }
+
+    @Test("saveDetail cancels previous debounce on rapid changes")
+    @MainActor func saveDetailCancelsPrevious() async throws {
+        let task = makeTask()
+        let (vm, service) = makeVM(task: task)
+        service.updateResult = .success(task)
+
+        vm.detail = "First"
+        vm.saveDetail()
+        try await Task.sleep(for: .milliseconds(500))
+
+        vm.detail = "Second"
+        vm.saveDetail()
+        try await Task.sleep(for: .milliseconds(500))
+
+        // Only 500ms since last call, so no API calls yet.
+        #expect(service.updateCallCount == 0)
+
+        // Wait for second debounce to complete.
+        try await Task.sleep(for: .milliseconds(700))
+        #expect(service.updateCallCount == 1)
+    }
+
+    // MARK: - Complete Task
+
+    @Test("completeTask sets done status and calls onComplete")
+    @MainActor func completeTaskSuccess() async throws {
+        let task = makeTask()
+        let completedTask = TaskModel(id: "t-1", playbookId: "pb-1", title: "Test Task", status: .done, completedAt: .now)
+        var completedId: String?
+
+        let service = MockTaskService()
+        service.completeResult = .success(completedTask)
+
+        let vm = TaskDetailViewModel(
+            task: task,
+            taskService: service,
+            onComplete: { completedId = $0 },
+            onDelete: { _ in }
+        )
+
+        vm.completeTask()
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(task.status == .done)
+        #expect(task.completedAt != nil)
+        #expect(service.completeCallCount == 1)
+        #expect(completedId == "t-1")
+    }
+
+    @Test("completeTask rolls back on error")
+    @MainActor func completeTaskRollback() async throws {
+        let task = makeTask()
+        let service = MockTaskService()
+        service.completeResult = .failure(.serverError("Server error"))
+
+        let (vm, _) = makeVM(task: task, mockService: service)
+
+        vm.completeTask()
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(task.status == .open)
+        #expect(task.completedAt == nil)
+        #expect(vm.error != nil)
+    }
+
+    @Test("completeTask does nothing when task is already done")
+    @MainActor func completeTaskAlreadyDone() async throws {
+        let task = makeTask(status: .done)
+        let (vm, service) = makeVM(task: task)
+
+        vm.completeTask()
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(service.completeCallCount == 0)
+    }
+
+    // MARK: - Delete Task
+
+    @Test("deleteTask calls service and onDelete callback")
+    @MainActor func deleteTaskSuccess() async throws {
+        var deletedId: String?
+        let service = MockTaskService()
+
+        let vm = TaskDetailViewModel(
+            task: makeTask(),
+            taskService: service,
+            onComplete: { _ in },
+            onDelete: { deletedId = $0 }
+        )
+
+        vm.deleteTask()
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(service.deleteCallCount == 1)
+        #expect(deletedId == "t-1")
+    }
+
+    @Test("deleteTask error sets error string")
+    @MainActor func deleteTaskError() async throws {
+        let service = MockTaskService()
+        service.deleteResult = .failure(.serverError("Server error"))
+
+        let (vm, _) = makeVM(mockService: service)
+
+        vm.deleteTask()
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(vm.error != nil)
+        #expect(vm.isSubmitting == false)
+    }
+}


### PR DESCRIPTION
## Summary
- New `TaskDetailSheet` expandable half-sheet (`.medium` / `.large` detents)
- Status pill (blue OPEN / green DONE) at top
- Inline editable title with save on commit
- Lane selector using existing `LaneChipGroup` — immediate save
- Estimate selector using `TimeEstimatePickerRow` with `[30, 60, 90, 120, 180]` — immediate save
- Warning text when estimate exceeds 180 minutes
- Notes `TextEditor` with placeholder and 1-second debounced save
- "Complete Task" button (green accent) — optimistic update with rollback on error
- "Delete Task" button (red border) with confirmation dialog
- Replaces `TaskDetailPlaceholder` in PlaybookHomeView
- Exposed `taskService` from `PlaybookHomeViewModel` (private → internal)
- 16 ViewModel tests covering editing, debounce, complete, delete, rollback

## Test plan
- [x] `xcodebuild build` — zero errors
- [x] `xcodebuild test` — all 180 tests pass (16 new + 164 existing)
- [ ] Manual: tap task card → detail sheet opens at half-height
- [ ] Manual: drag to expand → sheet goes full height
- [ ] Manual: edit title → persists on submit
- [ ] Manual: change lane/estimate → immediate update
- [ ] Manual: type notes → saves after 1s pause
- [ ] Manual: select 180m → warning shown
- [ ] Manual: Complete → task marked done, sheet dismisses
- [ ] Manual: Delete → confirmation → deletes and dismisses

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)