### PR TITLE
feat: SectionService — fetch and update sections (#24)

### DIFF
--- a/idea-pilot/idea-pilot/App/idea_pilotApp.swift
+++ b/idea-pilot/idea-pilot/App/idea_pilotApp.swift
@@ -24,6 +24,7 @@ struct idea_pilotApp: App {
     let authService: AuthService
     let playbookService: PlaybookService
     let taskService: TaskService
+    let sectionService: SectionService
 
     init() {
         let container = try! ModelContainer(for: PlaybookModel.self)
@@ -43,6 +44,7 @@ struct idea_pilotApp: App {
 
         let playbooks = PlaybookService(apiClient: client, modelContainer: container)
         let tasks = TaskService(apiClient: client, modelContainer: container)
+        let sections = SectionService(apiClient: client, modelContainer: container)
 
         self.modelContainer = container
         self.tokenManager = tm
@@ -50,11 +52,12 @@ struct idea_pilotApp: App {
         self.authService = auth
         self.playbookService = playbooks
         self.taskService = tasks
+        self.sectionService = sections
     }
 
     var body: some Scene {
         WindowGroup {
-            RootView(tokenManager: tokenManager, authService: authService, playbookService: playbookService, taskService: taskService)
+            RootView(tokenManager: tokenManager, authService: authService, playbookService: playbookService, taskService: taskService, sectionService: sectionService)
         }
         .modelContainer(modelContainer)
     }

--- a/idea-pilot/idea-pilot/Core/Networking/Endpoint.swift
+++ b/idea-pilot/idea-pilot/Core/Networking/Endpoint.swift
@@ -150,8 +150,12 @@ extension Endpoint {
 
 extension Endpoint {
 
-    static func getSections(playbookId: String) -> Endpoint {
-        Endpoint(path: "/v1/playbooks/\(playbookId)/sections", method: .get)
+    static func getSections(playbookId: String, updatedSince: Date? = nil) -> Endpoint {
+        var queryItems: [URLQueryItem]?
+        if let date = updatedSince {
+            queryItems = [URLQueryItem(name: "updated_since", value: ISO8601DateFormatter().string(from: date))]
+        }
+        return Endpoint(path: "/v1/playbooks/\(playbookId)/sections", method: .get, queryItems: queryItems)
     }
 
     static func updateSection(playbookId: String, sectionType: String, dto: UpdateSectionDTO) -> Endpoint {

--- a/idea-pilot/idea-pilot/Features/Playbooks/Views/PlaybookListView.swift
+++ b/idea-pilot/idea-pilot/Features/Playbooks/Views/PlaybookListView.swift
@@ -20,6 +20,7 @@ struct PlaybookListView: View {
 
     @Bindable var vm: PlaybookListViewModel
     let taskService: any TaskServiceProtocol
+    let sectionService: any SectionServiceProtocol
 
     var body: some View {
         ScrollView {
@@ -69,6 +70,7 @@ struct PlaybookListView: View {
                 PlaybookCardRow(
                     playbook: playbook,
                     taskService: taskService,
+                    sectionService: sectionService,
                     onArchive: { vm.archivePlaybook(id: playbook.id) }
                 )
             }
@@ -125,6 +127,7 @@ private struct PlaybookCardRow: View {
 
     let playbook: PlaybookModel
     let taskService: any TaskServiceProtocol
+    let sectionService: any SectionServiceProtocol
     let onArchive: () -> Void
 
     private var nowTaskCount: Int {
@@ -133,7 +136,7 @@ private struct PlaybookCardRow: View {
 
     var body: some View {
         NavigationLink {
-            PlaybookHomeView(vm: PlaybookHomeViewModel(playbook: playbook, taskService: taskService))
+            PlaybookHomeView(vm: PlaybookHomeViewModel(playbook: playbook, taskService: taskService, sectionService: sectionService))
         } label: {
             HStack(spacing: 12) {
                 VStack(alignment: .leading, spacing: 8) {
@@ -407,7 +410,8 @@ private struct CreatePlaybookSheet: View {
                 ]
                 return vm
             }(),
-            taskService: PlaybookListPreviewTaskService()
+            taskService: PlaybookListPreviewTaskService(),
+            sectionService: PlaybookListPreviewSectionService()
         )
     }
 }
@@ -416,7 +420,8 @@ private struct CreatePlaybookSheet: View {
     NavigationStack {
         PlaybookListView(
             vm: PlaybookListViewModel(playbookService: PlaybookListPreviewPlaybookService()),
-            taskService: PlaybookListPreviewTaskService()
+            taskService: PlaybookListPreviewTaskService(),
+            sectionService: PlaybookListPreviewSectionService()
         )
     }
 }
@@ -429,7 +434,8 @@ private struct CreatePlaybookSheet: View {
                 vm.error = "Network error. Please check your connection."
                 return vm
             }(),
-            taskService: PlaybookListPreviewTaskService()
+            taskService: PlaybookListPreviewTaskService(),
+            sectionService: PlaybookListPreviewSectionService()
         )
     }
 }
@@ -441,6 +447,14 @@ private struct PlaybookListPreviewPlaybookService: PlaybookServiceProtocol {
         PlaybookModel(id: UUID().uuidString, title: title)
     }
     func archivePlaybook(id: String) async throws {}
+}
+
+/// A no-op section service for SwiftUI previews.
+private struct PlaybookListPreviewSectionService: SectionServiceProtocol {
+    func fetchSections(playbookId: String, updatedSince: Date?) async throws -> [SectionModel] { [] }
+    func updateSection(playbookId: String, sectionType: SectionType, content: String) async throws -> SectionModel {
+        SectionModel(playbookId: playbookId, sectionType: sectionType, content: content)
+    }
 }
 
 /// A no-op task service for SwiftUI previews.

--- a/idea-pilot/idea-pilot/Features/Sections/Services/SectionService.swift
+++ b/idea-pilot/idea-pilot/Features/Sections/Services/SectionService.swift
@@ -1,0 +1,159 @@
+//
+//  SectionService.swift
+//  idea-pilot
+//
+//  Service handling section API calls and SwiftData persistence.
+//  Supports fetch (with incremental sync) and update operations.
+//
+
+import Foundation
+import SwiftData
+
+// MARK: - SectionError
+
+/// Errors specific to section operations.
+nonisolated enum SectionError: Error, Equatable, Sendable {
+    /// The requested section was not found (404).
+    case notFound
+    /// A network-level failure occurred.
+    case networkError(String)
+    /// The server returned an unexpected error.
+    case serverError(String)
+}
+
+// MARK: - SectionServiceProtocol
+
+/// Defines the section API surface for testability.
+nonisolated protocol SectionServiceProtocol: Sendable {
+    /// Fetches sections from the API, upserts into SwiftData, and returns the models.
+    /// Falls back to cached SwiftData data when offline.
+    func fetchSections(playbookId: String, updatedSince: Date?) async throws -> [SectionModel]
+
+    /// Updates section content on the server and in SwiftData.
+    func updateSection(playbookId: String, sectionType: SectionType, content: String) async throws -> SectionModel
+}
+
+// MARK: - SectionService
+
+/// Coordinates section CRUD through `APIClient` and SwiftData.
+///
+/// Each operation follows the standard pattern:
+/// Call the API → update SwiftData → return model(s).
+///
+/// `fetchSections` supports offline fallback by reading from SwiftData cache
+/// when the network is unavailable.
+final class SectionService: SectionServiceProtocol, Sendable {
+
+    private let apiClient: APIClient
+    private let modelContainer: ModelContainer
+
+    /// Creates a SectionService.
+    ///
+    /// - Parameters:
+    ///   - apiClient: The networking client for API calls.
+    ///   - modelContainer: The SwiftData container for local persistence.
+    init(apiClient: APIClient, modelContainer: ModelContainer) {
+        self.apiClient = apiClient
+        self.modelContainer = modelContainer
+    }
+
+    func fetchSections(playbookId: String, updatedSince: Date? = nil) async throws -> [SectionModel] {
+        do {
+            let dtos: [SectionDTO] = try await apiClient.request(
+                .getSections(playbookId: playbookId, updatedSince: updatedSince)
+            )
+            return try await upsertSections(dtos)
+        } catch let error as APIError {
+            if error.isOffline {
+                return try await cachedSections(playbookId: playbookId)
+            }
+            throw mapError(error)
+        } catch let error as SectionError {
+            throw error
+        } catch {
+            throw SectionError.serverError(error.localizedDescription)
+        }
+    }
+
+    func updateSection(playbookId: String, sectionType: SectionType, content: String) async throws -> SectionModel {
+        do {
+            let dto = UpdateSectionDTO(content: content)
+            let response: SectionDTO = try await apiClient.request(
+                .updateSection(playbookId: playbookId, sectionType: sectionType.rawValue, dto: dto)
+            )
+            return try await upsertSingleSection(response)
+        } catch let error as APIError {
+            throw mapError(error)
+        } catch let error as SectionError {
+            throw error
+        } catch {
+            throw SectionError.serverError(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Private — SwiftData Operations
+
+    /// Upserts an array of section DTOs into SwiftData.
+    @MainActor
+    private func upsertSections(_ dtos: [SectionDTO]) throws -> [SectionModel] {
+        let context = modelContainer.mainContext
+        var models: [SectionModel] = []
+
+        for dto in dtos {
+            let compositeId = "\(dto.playbookId)_\(dto.sectionType)"
+
+            let predicate = #Predicate<SectionModel> { $0.compositeId == compositeId }
+            var descriptor = FetchDescriptor(predicate: predicate)
+            descriptor.fetchLimit = 1
+
+            if let existing = try context.fetch(descriptor).first {
+                existing.content = dto.content
+                existing.updatedAt = dto.updatedAt
+                models.append(existing)
+            } else {
+                let model = dto.toModel()
+                context.insert(model)
+                models.append(model)
+            }
+        }
+
+        try context.save()
+        return models
+    }
+
+    /// Upserts a single section DTO into SwiftData.
+    @MainActor
+    private func upsertSingleSection(_ dto: SectionDTO) throws -> SectionModel {
+        try upsertSections([dto]).first!
+    }
+
+    /// Returns cached sections from SwiftData (offline fallback).
+    @MainActor
+    private func cachedSections(playbookId: String) throws -> [SectionModel] {
+        let context = modelContainer.mainContext
+        let predicate = #Predicate<SectionModel> { $0.playbookId == playbookId }
+        let descriptor = FetchDescriptor(predicate: predicate)
+        return try context.fetch(descriptor)
+    }
+
+    // MARK: - Private — Error Mapping
+
+    private func mapError(_ error: APIError) -> SectionError {
+        switch error {
+        case .notFound:
+            return .notFound
+        case .networkError(let urlError):
+            return .networkError(urlError.localizedDescription)
+        case .offline:
+            return .networkError("No internet connection")
+        case .serverError(_, let message):
+            return .serverError(message ?? "Server error")
+        case .badRequest(let message):
+            return .serverError(message ?? "Bad request")
+        case .sessionExpired:
+            return .serverError("Session expired")
+        case .decodingError(let message):
+            return .serverError("Invalid response: \(message)")
+        }
+    }
+}

--- a/idea-pilot/idea-pilot/Features/Tasks/ViewModels/PlaybookHomeViewModel.swift
+++ b/idea-pilot/idea-pilot/Features/Tasks/ViewModels/PlaybookHomeViewModel.swift
@@ -72,6 +72,7 @@ final class PlaybookHomeViewModel {
     // MARK: - Dependencies
 
     let taskService: any TaskServiceProtocol
+    let sectionService: any SectionServiceProtocol
 
     // MARK: - Init
 
@@ -80,9 +81,11 @@ final class PlaybookHomeViewModel {
     /// - Parameters:
     ///   - playbook: The playbook whose tasks are managed.
     ///   - taskService: The service for task API calls and persistence.
-    init(playbook: PlaybookModel, taskService: any TaskServiceProtocol) {
+    ///   - sectionService: The service for section API calls and persistence.
+    init(playbook: PlaybookModel, taskService: any TaskServiceProtocol, sectionService: any SectionServiceProtocol) {
         self.playbook = playbook
         self.taskService = taskService
+        self.sectionService = sectionService
     }
 
     // MARK: - Actions

--- a/idea-pilot/idea-pilot/Features/Tasks/Views/PlaybookHomeView.swift
+++ b/idea-pilot/idea-pilot/Features/Tasks/Views/PlaybookHomeView.swift
@@ -651,7 +651,8 @@ private struct EmptyLaneView: View {
         PlaybookHomeView(vm: {
             let vm = PlaybookHomeViewModel(
                 playbook: PlaybookModel(id: "pb-1", title: "Side Hustle App", phase: .proof),
-                taskService: PreviewTaskService()
+                taskService: PreviewTaskService(),
+                sectionService: PreviewSectionService()
             )
             vm.allTasks = [
                 TaskModel(id: "t-1", playbookId: "pb-1", title: "Research competitors", lane: .now, estimatedMinutes: 90, orderIndex: 0),
@@ -668,8 +669,17 @@ private struct EmptyLaneView: View {
     NavigationStack {
         PlaybookHomeView(vm: PlaybookHomeViewModel(
             playbook: PlaybookModel(id: "pb-1", title: "Empty Playbook"),
-            taskService: PreviewTaskService()
+            taskService: PreviewTaskService(),
+            sectionService: PreviewSectionService()
         ))
+    }
+}
+
+/// A no-op section service for SwiftUI previews.
+private struct PreviewSectionService: SectionServiceProtocol {
+    func fetchSections(playbookId: String, updatedSince: Date?) async throws -> [SectionModel] { [] }
+    func updateSection(playbookId: String, sectionType: SectionType, content: String) async throws -> SectionModel {
+        SectionModel(playbookId: playbookId, sectionType: sectionType, content: content)
     }
 }
 

--- a/idea-pilot/idea-pilot/Models/Enums.swift
+++ b/idea-pilot/idea-pilot/Models/Enums.swift
@@ -65,4 +65,14 @@ enum SectionType: String, Codable, Hashable, CaseIterable, Sendable {
     case system = "SYSTEM"
     case build = "BUILD"
     case businessModel = "BUSINESS_MODEL"
+
+    /// Human-readable display name for the UI.
+    var displayName: String {
+        switch self {
+        case .vision: "Vision"
+        case .system: "System"
+        case .build: "Build"
+        case .businessModel: "Business Model"
+        }
+    }
 }

--- a/idea-pilot/idea-pilot/Navigation/MainTabView.swift
+++ b/idea-pilot/idea-pilot/Navigation/MainTabView.swift
@@ -58,15 +58,17 @@ struct MainTabView: View {
 
     let taskService: any TaskServiceProtocol
     let playbookService: any PlaybookServiceProtocol
+    let sectionService: any SectionServiceProtocol
 
     @State private var selectedTab: AppTab = .now
     @State private var playbookListVM: PlaybookListViewModel
     @State private var showQuickAddSheet = false
 
-    init(playbookService: any PlaybookServiceProtocol, taskService: any TaskServiceProtocol, onSignOut: @escaping () -> Void) {
+    init(playbookService: any PlaybookServiceProtocol, taskService: any TaskServiceProtocol, sectionService: any SectionServiceProtocol, onSignOut: @escaping () -> Void) {
         self.onSignOut = onSignOut
         self.taskService = taskService
         self.playbookService = playbookService
+        self.sectionService = sectionService
         self._playbookListVM = State(initialValue: PlaybookListViewModel(playbookService: playbookService))
     }
 
@@ -103,7 +105,7 @@ struct MainTabView: View {
             .opacity(selectedTab == .now ? 1 : 0)
 
             NavigationStack {
-                PlaybookListView(vm: playbookListVM, taskService: taskService)
+                PlaybookListView(vm: playbookListVM, taskService: taskService, sectionService: sectionService)
             }
             .opacity(selectedTab == .playbooks ? 1 : 0)
         }
@@ -220,6 +222,7 @@ private struct NowPlaceholderView: View {
     MainTabView(
         playbookService: MainTabPreviewPlaybookService(),
         taskService: MainTabPreviewTaskService(),
+        sectionService: MainTabPreviewSectionService(),
         onSignOut: {}
     )
 }
@@ -231,6 +234,14 @@ private struct MainTabPreviewPlaybookService: PlaybookServiceProtocol {
         PlaybookModel(id: UUID().uuidString, title: title)
     }
     func archivePlaybook(id: String) async throws {}
+}
+
+/// A no-op section service for MainTabView previews.
+private struct MainTabPreviewSectionService: SectionServiceProtocol {
+    func fetchSections(playbookId: String, updatedSince: Date?) async throws -> [SectionModel] { [] }
+    func updateSection(playbookId: String, sectionType: SectionType, content: String) async throws -> SectionModel {
+        SectionModel(playbookId: playbookId, sectionType: sectionType, content: content)
+    }
 }
 
 /// A no-op task service for MainTabView previews.

--- a/idea-pilot/idea-pilot/Navigation/RootView.swift
+++ b/idea-pilot/idea-pilot/Navigation/RootView.swift
@@ -21,6 +21,7 @@ struct RootView: View {
     let authService: any AuthServiceProtocol
     let playbookService: any PlaybookServiceProtocol
     let taskService: any TaskServiceProtocol
+    let sectionService: any SectionServiceProtocol
 
     @State private var isAuthenticated = false
     @State private var isCheckingAuth = true
@@ -31,7 +32,7 @@ struct RootView: View {
             if isCheckingAuth {
                 splashView
             } else if isAuthenticated {
-                MainTabView(playbookService: playbookService, taskService: taskService, onSignOut: signOut)
+                MainTabView(playbookService: playbookService, taskService: taskService, sectionService: sectionService, onSignOut: signOut)
             } else if let vm = authViewModel {
                 AuthView(vm: vm)
             }

--- a/idea-pilot/idea-pilotTests/PlaybookHomeViewModelTests.swift
+++ b/idea-pilot/idea-pilotTests/PlaybookHomeViewModelTests.swift
@@ -84,6 +84,16 @@ final class MockTaskService: TaskServiceProtocol, @unchecked Sendable {
     }
 }
 
+// MARK: - Stub Section Service
+
+/// Minimal stub for SectionServiceProtocol used when tests don't exercise section logic.
+private final class StubSectionService: SectionServiceProtocol, @unchecked Sendable {
+    nonisolated func fetchSections(playbookId: String, updatedSince: Date?) async throws -> [SectionModel] { [] }
+    nonisolated func updateSection(playbookId: String, sectionType: SectionType, content: String) async throws -> SectionModel {
+        SectionModel(playbookId: playbookId, sectionType: sectionType, content: content)
+    }
+}
+
 // MARK: - Test Helpers
 
 private func makeSamplePlaybook() -> PlaybookModel {
@@ -117,7 +127,7 @@ struct PlaybookHomeViewModelTests {
     @MainActor func loadTasksSuccess() async throws {
         let mockService = MockTaskService()
         mockService.fetchResult = .success(makeSampleTasks())
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService)
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
 
         vm.loadTasks()
         try await Task.sleep(for: .milliseconds(50))
@@ -132,7 +142,7 @@ struct PlaybookHomeViewModelTests {
     @MainActor func loadTasksError() async throws {
         let mockService = MockTaskService()
         mockService.fetchResult = .failure(.networkError("timeout"))
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService)
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
 
         vm.loadTasks()
         try await Task.sleep(for: .milliseconds(50))
@@ -148,7 +158,7 @@ struct PlaybookHomeViewModelTests {
     @MainActor func refreshCallsFetch() async throws {
         let mockService = MockTaskService()
         mockService.fetchResult = .success(makeSampleTasks())
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService)
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
 
         await vm.refresh()
 
@@ -162,7 +172,7 @@ struct PlaybookHomeViewModelTests {
     @Test("tasksInCurrentLane returns only NOW tasks by default")
     @MainActor func laneFilteringNow() {
         let mockService = MockTaskService()
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService)
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
         vm.allTasks = makeSampleTasks()
 
         let nowTasks = vm.tasksInCurrentLane
@@ -173,7 +183,7 @@ struct PlaybookHomeViewModelTests {
     @Test("selectLane switches to NEXT and filters correctly")
     @MainActor func laneFilteringNext() {
         let mockService = MockTaskService()
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService)
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
         vm.allTasks = makeSampleTasks()
 
         vm.selectLane(.next)
@@ -186,7 +196,7 @@ struct PlaybookHomeViewModelTests {
     @Test("tasksInCurrentLane excludes completed tasks")
     @MainActor func laneFilteringHidesDone() {
         let mockService = MockTaskService()
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService)
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
         vm.allTasks = makeMixedStatusTasks()
 
         let tasks = vm.tasksInCurrentLane
@@ -197,7 +207,7 @@ struct PlaybookHomeViewModelTests {
     @Test("taskCounts returns correct counts per lane")
     @MainActor func taskCountsPerLane() {
         let mockService = MockTaskService()
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService)
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
         vm.allTasks = makeSampleTasks()
 
         let counts = vm.taskCounts
@@ -214,7 +224,7 @@ struct PlaybookHomeViewModelTests {
         let completedTask = TaskModel(id: "t-1", playbookId: "pb-1", title: "Now Task 1", lane: .now, status: .done, completedAt: .now)
         mockService.completeResult = .success(completedTask)
 
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService)
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
         vm.allTasks = makeSampleTasks()
 
         vm.completeTask(id: "t-1")
@@ -231,7 +241,7 @@ struct PlaybookHomeViewModelTests {
         let mockService = MockTaskService()
         mockService.completeResult = .failure(.serverError("Server error"))
 
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService)
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
         vm.allTasks = makeSampleTasks()
 
         vm.completeTask(id: "t-1")
@@ -248,7 +258,7 @@ struct PlaybookHomeViewModelTests {
         let movedTask = TaskModel(id: "t-1", playbookId: "pb-1", title: "Now Task 1", lane: .next, orderIndex: 0)
         mockService.updateResult = .success(movedTask)
 
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService)
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
         vm.allTasks = makeSampleTasks()
 
         vm.moveTask(id: "t-1", toLane: .next)
@@ -266,7 +276,7 @@ struct PlaybookHomeViewModelTests {
     @Test("reorderTasks updates local orderIndex and calls service")
     @MainActor func reorderTasksSuccess() async throws {
         let mockService = MockTaskService()
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService)
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
         vm.allTasks = makeSampleTasks()
 
         // Reverse the order of NOW tasks.
@@ -289,7 +299,7 @@ struct PlaybookHomeViewModelTests {
     @Test("emptyStateMessage returns correct message per lane")
     @MainActor func emptyStateMessages() {
         let mockService = MockTaskService()
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService)
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
 
         vm.selectLane(.now)
         #expect(vm.emptyStateMessage == "No active tasks. Move a task to Now to get started.")
@@ -306,7 +316,7 @@ struct PlaybookHomeViewModelTests {
     @Test("selectTask and clearSelectedTask manage detail sheet state")
     @MainActor func selectAndClearTask() {
         let mockService = MockTaskService()
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService)
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
         let task = TaskModel(playbookId: "pb-1", title: "Test Task")
 
         vm.selectTask(task)

--- a/idea-pilot/idea-pilotTests/SectionServiceTests.swift
+++ b/idea-pilot/idea-pilotTests/SectionServiceTests.swift
@@ -1,0 +1,303 @@
+//
+//  SectionServiceTests.swift
+//  idea-pilotTests
+//
+//  Unit tests for SectionService with mock networking and in-memory SwiftData.
+//
+
+import Foundation
+import SwiftData
+import Testing
+@testable import idea_pilot
+
+// MARK: - Mock URL Protocol (independent from other test suites)
+
+/// A `URLProtocol` subclass for SectionService tests, independent of other mocks.
+final class SectionServiceMockURLProtocol: URLProtocol, @unchecked Sendable {
+
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> (Data, HTTPURLResponse))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = SectionServiceMockURLProtocol.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+
+        do {
+            let (data, response) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Test Helpers
+
+private let testBaseURL = URL(string: "https://api.test.ideapilot.app")!
+
+private func makeURLSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [SectionServiceMockURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+private nonisolated func makeResponse(statusCode: Int) -> HTTPURLResponse {
+    HTTPURLResponse(
+        url: testBaseURL,
+        statusCode: statusCode,
+        httpVersion: nil,
+        headerFields: nil
+    )!
+}
+
+private nonisolated func makeInMemoryModelContainer() throws -> ModelContainer {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    return try ModelContainer(
+        for: PlaybookModel.self, TaskModel.self, SectionModel.self, WeeklyCycleModel.self,
+        configurations: config
+    )
+}
+
+private nonisolated func makeSectionService(
+    session: URLSession? = nil
+) throws -> (SectionService, ModelContainer) {
+    let urlSession = session ?? makeURLSession()
+    let apiClient = APIClient(baseURL: testBaseURL, session: urlSession)
+    let container = try makeInMemoryModelContainer()
+    let service = SectionService(apiClient: apiClient, modelContainer: container)
+    return (service, container)
+}
+
+// MARK: - Mock JSON Fixtures
+
+private let sectionsArrayJSON = #"""
+[
+    {
+        "playbook_id": "pb-1",
+        "section_type": "VISION",
+        "content": "Our vision is...",
+        "updated_at": "2025-01-01T00:00:00Z"
+    },
+    {
+        "playbook_id": "pb-1",
+        "section_type": "SYSTEM",
+        "content": "The system works by...",
+        "updated_at": "2025-01-02T00:00:00Z"
+    },
+    {
+        "playbook_id": "pb-1",
+        "section_type": "BUILD",
+        "content": "",
+        "updated_at": "2025-01-03T00:00:00Z"
+    },
+    {
+        "playbook_id": "pb-1",
+        "section_type": "BUSINESS_MODEL",
+        "content": "Revenue streams include...",
+        "updated_at": "2025-01-04T00:00:00Z"
+    }
+]
+"""#
+
+private let updatedSectionJSON = #"""
+{
+    "playbook_id": "pb-1",
+    "section_type": "VISION",
+    "content": "Updated vision content",
+    "updated_at": "2025-01-10T00:00:00Z"
+}
+"""#
+
+// MARK: - Tests
+
+@Suite("SectionService", .serialized)
+struct SectionServiceTests {
+
+    // MARK: - Fetch
+
+    @Test("fetchSections decodes array and upserts into SwiftData")
+    func fetchSectionsSuccess() async throws {
+        SectionServiceMockURLProtocol.handler = { _ in
+            (Data(sectionsArrayJSON.utf8), makeResponse(statusCode: 200))
+        }
+        let (service, container) = try makeSectionService()
+
+        let models = try await service.fetchSections(playbookId: "pb-1", updatedSince: nil)
+
+        #expect(models.count == 4)
+        #expect(models.contains { $0.sectionType == .vision && $0.content == "Our vision is..." })
+        #expect(models.contains { $0.sectionType == .system })
+        #expect(models.contains { $0.sectionType == .build })
+        #expect(models.contains { $0.sectionType == .businessModel })
+
+        // Verify persisted in SwiftData.
+        let context = await container.mainContext
+        let descriptor = FetchDescriptor<SectionModel>()
+        let persisted = try await context.fetch(descriptor)
+        #expect(persisted.count == 4)
+
+        SectionServiceMockURLProtocol.handler = nil
+    }
+
+    @Test("fetchSections upserts existing sections instead of duplicating")
+    func fetchSectionsUpserts() async throws {
+        let (service, container) = try makeSectionService()
+
+        // First fetch — seed all 4 sections.
+        SectionServiceMockURLProtocol.handler = { _ in
+            (Data(sectionsArrayJSON.utf8), makeResponse(statusCode: 200))
+        }
+        _ = try await service.fetchSections(playbookId: "pb-1", updatedSince: nil)
+
+        // Second fetch — only vision with updated content.
+        let updatedArrayJSON = #"""
+        [
+            {
+                "playbook_id": "pb-1",
+                "section_type": "VISION",
+                "content": "New vision",
+                "updated_at": "2025-02-01T00:00:00Z"
+            }
+        ]
+        """#
+        SectionServiceMockURLProtocol.handler = { _ in
+            (Data(updatedArrayJSON.utf8), makeResponse(statusCode: 200))
+        }
+        let models = try await service.fetchSections(playbookId: "pb-1", updatedSince: nil)
+
+        #expect(models.count == 1)
+        #expect(models.first?.content == "New vision")
+
+        // Total should still be 4 (3 from first + 1 upserted).
+        let context = await container.mainContext
+        let descriptor = FetchDescriptor<SectionModel>()
+        let persisted = try await context.fetch(descriptor)
+        #expect(persisted.count == 4)
+
+        SectionServiceMockURLProtocol.handler = nil
+    }
+
+    @Test("fetchSections falls back to SwiftData cache when offline")
+    func fetchSectionsOfflineFallback() async throws {
+        let (service, container) = try makeSectionService()
+
+        // Pre-populate cache.
+        let context = await container.mainContext
+        let cached = SectionModel(playbookId: "pb-1", sectionType: .vision, content: "Cached vision")
+        await context.insert(cached)
+        try await context.save()
+
+        // Simulate offline.
+        SectionServiceMockURLProtocol.handler = { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+
+        let models = try await service.fetchSections(playbookId: "pb-1", updatedSince: nil)
+        #expect(models.count == 1)
+        #expect(models.first?.content == "Cached vision")
+
+        SectionServiceMockURLProtocol.handler = nil
+    }
+
+    @Test("fetchSections server error throws SectionError.serverError")
+    func fetchSectionsServerError() async throws {
+        let errorJSON = #"{"message":"Internal server error"}"#
+        SectionServiceMockURLProtocol.handler = { _ in
+            (Data(errorJSON.utf8), makeResponse(statusCode: 500))
+        }
+        let (service, _) = try makeSectionService()
+
+        do {
+            _ = try await service.fetchSections(playbookId: "pb-1", updatedSince: nil)
+            Issue.record("Expected SectionError.serverError")
+        } catch let error as SectionError {
+            guard case .serverError = error else {
+                Issue.record("Expected serverError, got \(error)")
+                return
+            }
+        }
+
+        SectionServiceMockURLProtocol.handler = nil
+    }
+
+    // MARK: - Update
+
+    @Test("updateSection sends PUT and upserts response into SwiftData")
+    func updateSectionSuccess() async throws {
+        nonisolated(unsafe) var capturedMethod: String?
+        nonisolated(unsafe) var capturedPath: String?
+
+        SectionServiceMockURLProtocol.handler = { request in
+            capturedMethod = request.httpMethod
+            capturedPath = request.url?.path
+            return (Data(updatedSectionJSON.utf8), makeResponse(statusCode: 200))
+        }
+
+        let (service, container) = try makeSectionService()
+
+        let model = try await service.updateSection(
+            playbookId: "pb-1",
+            sectionType: .vision,
+            content: "Updated vision content"
+        )
+
+        #expect(capturedMethod == "PUT")
+        #expect(capturedPath?.contains("/v1/playbooks/pb-1/sections/VISION") == true)
+        #expect(model.content == "Updated vision content")
+        #expect(model.sectionType == .vision)
+
+        // Verify persisted in SwiftData.
+        let context = await container.mainContext
+        let descriptor = FetchDescriptor<SectionModel>()
+        let persisted = try await context.fetch(descriptor)
+        #expect(persisted.count == 1)
+        #expect(persisted.first?.content == "Updated vision content")
+
+        SectionServiceMockURLProtocol.handler = nil
+    }
+
+    @Test("updateSection 404 throws SectionError.notFound")
+    func updateSectionNotFound() async throws {
+        SectionServiceMockURLProtocol.handler = { _ in
+            (Data(), makeResponse(statusCode: 404))
+        }
+        let (service, _) = try makeSectionService()
+
+        do {
+            _ = try await service.updateSection(playbookId: "pb-1", sectionType: .vision, content: "text")
+            Issue.record("Expected SectionError.notFound")
+        } catch let error as SectionError {
+            #expect(error == .notFound)
+        }
+
+        SectionServiceMockURLProtocol.handler = nil
+    }
+
+    @Test("updateSection network error throws SectionError.networkError")
+    func updateSectionNetworkError() async throws {
+        SectionServiceMockURLProtocol.handler = { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+        let (service, _) = try makeSectionService()
+
+        do {
+            _ = try await service.updateSection(playbookId: "pb-1", sectionType: .vision, content: "text")
+            Issue.record("Expected SectionError.networkError")
+        } catch let error as SectionError {
+            guard case .networkError = error else {
+                Issue.record("Expected networkError, got \(error)")
+                return
+            }
+        }
+
+        SectionServiceMockURLProtocol.handler = nil
+    }
+}


### PR DESCRIPTION
## Summary
- Add `SectionServiceProtocol` + `SectionService` implementation following existing TaskService patterns
- SwiftData upsert by `compositeId`, offline fallback to cache, error mapping
- Thread `sectionService` through full DI chain (App → Root → Tabs → PlaybookList → PlaybookHome)
- Add `displayName` computed property to `SectionType` enum
- Add `updatedSince` parameter to `getSections` endpoint
- 7 new service tests (187 total passing)

## Files Modified
- **New:** `Features/Sections/Services/SectionService.swift` — protocol, error enum, implementation
- **New:** `idea-pilotTests/SectionServiceTests.swift` — 7 tests with mock URLProtocol
- **Modified:** `Models/Enums.swift` — `displayName` on `SectionType`
- **Modified:** `Core/Networking/Endpoint.swift` — `updatedSince` on `getSections`
- **Modified:** DI chain (6 files): `idea_pilotApp`, `RootView`, `MainTabView`, `PlaybookListView`, `PlaybookHomeViewModel`, `PlaybookHomeView`
- **Modified:** `PlaybookHomeViewModelTests.swift` — updated for new `sectionService` init param

## Test plan
- [x] Build succeeds with zero errors
- [x] All 187 tests pass (180 existing + 7 new)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)