### PR TITLE
feat: Sections list and editor views (#25)

### DIFF
--- a/idea-pilot/idea-pilot/Features/Sections/ViewModels/SectionsViewModel.swift
+++ b/idea-pilot/idea-pilot/Features/Sections/ViewModels/SectionsViewModel.swift
@@ -1,0 +1,190 @@
+//
+//  SectionsViewModel.swift
+//  idea-pilot
+//
+//  ViewModel for the Sections list and editor screens.
+//  Manages fetching all 4 sections, displaying them in a list,
+//  and auto-saving editor content with a 1-second debounce.
+//
+
+import Foundation
+
+/// Drives the Sections list and editor screens for a playbook.
+///
+/// Manages fetching all 4 sections, displaying them in a list,
+/// and auto-saving editor content with a 1-second debounce.
+@Observable
+final class SectionsViewModel {
+
+    // MARK: - List State
+
+    var sections: [SectionModel] = []
+    var isLoading = false
+    var error: String?
+
+    // MARK: - Editor State
+
+    /// The content being edited in the section editor (bound to TextEditor).
+    var editorContent: String = ""
+
+    /// The section currently being edited, set when navigating to the editor.
+    private(set) var editingSection: SectionModel?
+
+    // MARK: - Computed
+
+    /// Sections ordered by the fixed SectionType.allCases order.
+    var orderedSections: [SectionModel] {
+        let typeOrder = SectionType.allCases
+        return typeOrder.compactMap { type in
+            sections.first { $0.sectionType == type }
+        }
+    }
+
+    /// Character count of the current editor content.
+    var characterCount: Int {
+        editorContent.count
+    }
+
+    /// Word count of the current editor content.
+    var wordCount: Int {
+        let trimmed = editorContent.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return 0 }
+        return trimmed.components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .count
+    }
+
+    /// First line of content for a section, used as preview text in the list.
+    func previewText(for section: SectionModel) -> String {
+        let firstLine = section.content
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .components(separatedBy: .newlines)
+            .first ?? ""
+        return firstLine.isEmpty ? "No content yet" : firstLine
+    }
+
+    // MARK: - Dependencies
+
+    let playbook: PlaybookModel
+    private let sectionService: any SectionServiceProtocol
+
+    /// Tracks the debounced save task so it can be cancelled on new input.
+    private var saveTask: Task<Void, Never>?
+
+    // MARK: - Init
+
+    init(playbook: PlaybookModel, sectionService: any SectionServiceProtocol) {
+        self.playbook = playbook
+        self.sectionService = sectionService
+    }
+
+    // MARK: - List Actions
+
+    /// Loads all sections for this playbook. Called on list appear.
+    func loadSections() {
+        error = nil
+        isLoading = true
+
+        Task {
+            defer { isLoading = false }
+
+            do {
+                sections = try await sectionService.fetchSections(
+                    playbookId: playbook.id,
+                    updatedSince: nil
+                )
+            } catch let sectionError as SectionError {
+                mapError(sectionError)
+            } catch {
+                self.error = "Something went wrong. Please try again."
+            }
+        }
+    }
+
+    /// Refreshes sections for pull-to-refresh.
+    func refresh() async {
+        error = nil
+
+        do {
+            sections = try await sectionService.fetchSections(
+                playbookId: playbook.id,
+                updatedSince: nil
+            )
+        } catch let sectionError as SectionError {
+            mapError(sectionError)
+        } catch {
+            self.error = "Something went wrong. Please try again."
+        }
+    }
+
+    // MARK: - Editor Actions
+
+    /// Prepares the editor for a specific section. Called when navigating to editor.
+    func startEditing(_ section: SectionModel) {
+        editingSection = section
+        editorContent = section.content
+    }
+
+    /// Saves the editor content with a 1-second debounce.
+    /// Updates the model immediately for responsive UI.
+    func saveContent() {
+        guard let section = editingSection else { return }
+
+        // Update model immediately for responsive UI.
+        section.content = editorContent
+
+        saveTask?.cancel()
+        saveTask = Task {
+            try? await Task.sleep(for: .seconds(1))
+            guard !Task.isCancelled else { return }
+
+            do {
+                _ = try await sectionService.updateSection(
+                    playbookId: section.playbookId,
+                    sectionType: section.sectionType,
+                    content: editorContent
+                )
+            } catch let sectionError as SectionError {
+                mapError(sectionError)
+            } catch {
+                self.error = "Failed to save. Please try again."
+            }
+        }
+    }
+
+    /// Forces an immediate save (e.g., on disappear). Cancels pending debounce.
+    func flushSave() {
+        guard let section = editingSection else { return }
+
+        saveTask?.cancel()
+
+        // Only fire if content actually changed from what the model has.
+        guard section.content != editorContent else { return }
+        section.content = editorContent
+
+        Task {
+            do {
+                _ = try await sectionService.updateSection(
+                    playbookId: section.playbookId,
+                    sectionType: section.sectionType,
+                    content: editorContent
+                )
+            } catch {
+                // Swallow on disappear — user is navigating away.
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func mapError(_ error: SectionError) {
+        switch error {
+        case .notFound:
+            self.error = "Section not found."
+        case .networkError:
+            self.error = "Network error. Please check your connection."
+        case .serverError:
+            self.error = "Something went wrong. Please try again."
+        }
+    }
+}

--- a/idea-pilot/idea-pilot/Features/Sections/Views/SectionEditorView.swift
+++ b/idea-pilot/idea-pilot/Features/Sections/Views/SectionEditorView.swift
@@ -1,0 +1,138 @@
+//
+//  SectionEditorView.swift
+//  idea-pilot
+//
+//  Full-screen plain text editor for a playbook section.
+//  Auto-saves with 1-second debounce, shows character/word count.
+//
+
+import SwiftUI
+
+/// Full-screen plain text editor for a playbook section.
+///
+/// Features:
+/// - Large TextEditor with placeholder
+/// - Auto-save with 1-second debounce on content change
+/// - Character and word count at bottom (subtle gray)
+/// - Flush save on disappear to prevent data loss
+struct SectionEditorView: View {
+
+    @Bindable var vm: SectionsViewModel
+    let section: SectionModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            editorArea
+
+            Divider()
+                .background(Color.theme.border)
+
+            wordCountBar
+        }
+        .themeBackground()
+        .navigationTitle(section.sectionType.displayName)
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            vm.startEditing(section)
+        }
+        .onDisappear {
+            vm.flushSave()
+        }
+    }
+
+    // MARK: - Editor Area
+
+    private var editorArea: some View {
+        ZStack(alignment: .topLeading) {
+            TextEditor(text: $vm.editorContent)
+                .font(.theme.bodyRegular)
+                .foregroundStyle(Color.theme.foreground)
+                .scrollContentBackground(.hidden)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+                .onChange(of: vm.editorContent) { _, _ in
+                    vm.saveContent()
+                }
+                .accessibilityLabel("\(section.sectionType.displayName) content")
+
+            if vm.editorContent.isEmpty {
+                Text("Start writing your \(section.sectionType.displayName.lowercased())...")
+                    .font(.theme.bodyRegular)
+                    .foregroundStyle(Color.theme.mutedForeground)
+                    .padding(.horizontal, 21)
+                    .padding(.vertical, 20)
+                    .allowsHitTesting(false)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Word Count Bar
+
+    private var wordCountBar: some View {
+        HStack {
+            Spacer()
+
+            Text("\(vm.characterCount) characters")
+                .font(.theme.caption)
+                .foregroundStyle(Color.theme.mutedForeground)
+
+            Text("  \u{00B7}  ")
+                .foregroundStyle(Color.theme.mutedForeground)
+
+            Text("\(vm.wordCount) words")
+                .font(.theme.caption)
+                .foregroundStyle(Color.theme.mutedForeground)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(vm.wordCount) words, \(vm.characterCount) characters")
+    }
+}
+
+// MARK: - Preview
+
+#Preview("With Content") {
+    NavigationStack {
+        SectionEditorView(
+            vm: {
+                let section = SectionModel(playbookId: "pb-1", sectionType: .vision, content: "Build the best productivity app for solopreneurs who need to ship fast and iterate weekly.")
+                let vm = SectionsViewModel(
+                    playbook: PlaybookModel(id: "pb-1", title: "Test Playbook"),
+                    sectionService: SectionEditorPreviewService()
+                )
+                vm.sections = [section]
+                vm.startEditing(section)
+                return vm
+            }(),
+            section: SectionModel(playbookId: "pb-1", sectionType: .vision, content: "Build the best productivity app for solopreneurs who need to ship fast and iterate weekly.")
+        )
+    }
+}
+
+#Preview("Empty") {
+    NavigationStack {
+        SectionEditorView(
+            vm: {
+                let section = SectionModel(playbookId: "pb-1", sectionType: .build, content: "")
+                let vm = SectionsViewModel(
+                    playbook: PlaybookModel(id: "pb-1", title: "Test Playbook"),
+                    sectionService: SectionEditorPreviewService()
+                )
+                vm.sections = [section]
+                vm.startEditing(section)
+                return vm
+            }(),
+            section: SectionModel(playbookId: "pb-1", sectionType: .build, content: "")
+        )
+    }
+}
+
+/// No-op section service for editor previews.
+private struct SectionEditorPreviewService: SectionServiceProtocol {
+    func fetchSections(playbookId: String, updatedSince: Date?) async throws -> [SectionModel] { [] }
+    func updateSection(playbookId: String, sectionType: SectionType, content: String) async throws -> SectionModel {
+        SectionModel(playbookId: playbookId, sectionType: sectionType, content: content)
+    }
+}

--- a/idea-pilot/idea-pilot/Features/Sections/Views/SectionsListView.swift
+++ b/idea-pilot/idea-pilot/Features/Sections/Views/SectionsListView.swift
@@ -1,0 +1,188 @@
+//
+//  SectionsListView.swift
+//  idea-pilot
+//
+//  Displays the 4 playbook sections (Vision, System, Build, Business Model)
+//  as a list. Tapping a row navigates to the full-screen section editor.
+//
+
+import SwiftUI
+
+/// Displays the 4 playbook sections as a list of card rows.
+///
+/// Each row shows the section name, a first-line content preview, and a chevron.
+/// Tapping a row navigates to the full-screen section editor.
+struct SectionsListView: View {
+
+    @Bindable var vm: SectionsViewModel
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 12) {
+                if let error = vm.error {
+                    errorBanner(error)
+                }
+
+                if vm.isLoading && vm.sections.isEmpty {
+                    loadingView
+                } else {
+                    sectionsList
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 8)
+        }
+        .refreshable { await vm.refresh() }
+        .onAppear { vm.loadSections() }
+        .themeBackground()
+        .navigationTitle("Sections")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    // MARK: - Sections List
+
+    private var sectionsList: some View {
+        LazyVStack(spacing: 12) {
+            ForEach(vm.orderedSections, id: \.compositeId) { section in
+                NavigationLink {
+                    SectionEditorView(vm: vm, section: section)
+                } label: {
+                    SectionRow(
+                        sectionType: section.sectionType,
+                        previewText: vm.previewText(for: section)
+                    )
+                }
+                .buttonStyle(.pressable)
+            }
+        }
+    }
+
+    // MARK: - Loading
+
+    private var loadingView: some View {
+        VStack(spacing: 16) {
+            Spacer().frame(height: 120)
+
+            ProgressView()
+                .tint(Color.theme.mutedForeground)
+
+            Text("Loading sections...")
+                .font(.theme.subheadline)
+                .foregroundStyle(Color.theme.mutedForeground)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Error Banner
+
+    private func errorBanner(_ message: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.subheadline)
+            Text(message)
+                .font(.theme.subheadline)
+        }
+        .foregroundStyle(Color.theme.destructive)
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.theme.destructive.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: .theme.radiusMd))
+        .overlay(
+            RoundedRectangle(cornerRadius: .theme.radiusMd)
+                .stroke(Color.theme.destructive.opacity(0.3), lineWidth: 1)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Error: \(message)")
+    }
+}
+
+// MARK: - Section Row
+
+/// A single row in the sections list showing name, preview, and chevron.
+private struct SectionRow: View {
+
+    let sectionType: SectionType
+    let previewText: String
+
+    /// SF Symbol icon for each section type.
+    private var iconName: String {
+        switch sectionType {
+        case .vision: "eye.fill"
+        case .system: "gearshape.2.fill"
+        case .build: "hammer.fill"
+        case .businessModel: "dollarsign.circle.fill"
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: iconName)
+                .font(.system(size: 20))
+                .foregroundStyle(Color.theme.primary)
+                .frame(width: 32)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(sectionType.displayName)
+                    .font(.theme.body)
+                    .foregroundStyle(Color.theme.foreground)
+
+                Text(previewText)
+                    .font(.theme.caption)
+                    .foregroundStyle(Color.theme.mutedForeground)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(Color.theme.mutedForeground)
+        }
+        .padding(16)
+        .cardStyle()
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(sectionType.displayName) section")
+        .accessibilityHint(previewText == "No content yet" ? "No content yet. Tap to edit." : "Tap to edit")
+    }
+}
+
+// MARK: - Preview
+
+#Preview("With Content") {
+    NavigationStack {
+        SectionsListView(vm: {
+            let vm = SectionsViewModel(
+                playbook: PlaybookModel(id: "pb-1", title: "Test Playbook"),
+                sectionService: SectionsListPreviewService()
+            )
+            vm.sections = [
+                SectionModel(playbookId: "pb-1", sectionType: .vision, content: "Build the best productivity app for solopreneurs"),
+                SectionModel(playbookId: "pb-1", sectionType: .system, content: "Daily standup, weekly review, monthly retro"),
+                SectionModel(playbookId: "pb-1", sectionType: .build, content: ""),
+                SectionModel(playbookId: "pb-1", sectionType: .businessModel, content: "Freemium with $9.99/mo pro tier"),
+            ]
+            return vm
+        }())
+    }
+}
+
+#Preview("Loading") {
+    NavigationStack {
+        SectionsListView(vm: {
+            let vm = SectionsViewModel(
+                playbook: PlaybookModel(id: "pb-1", title: "Test Playbook"),
+                sectionService: SectionsListPreviewService()
+            )
+            vm.isLoading = true
+            return vm
+        }())
+    }
+}
+
+/// No-op section service for SwiftUI previews.
+private struct SectionsListPreviewService: SectionServiceProtocol {
+    func fetchSections(playbookId: String, updatedSince: Date?) async throws -> [SectionModel] { [] }
+    func updateSection(playbookId: String, sectionType: SectionType, content: String) async throws -> SectionModel {
+        SectionModel(playbookId: playbookId, sectionType: sectionType, content: content)
+    }
+}

--- a/idea-pilot/idea-pilot/Features/Tasks/Views/PlaybookHomeView.swift
+++ b/idea-pilot/idea-pilot/Features/Tasks/Views/PlaybookHomeView.swift
@@ -21,6 +21,10 @@ struct PlaybookHomeView: View {
 
     @Bindable var vm: PlaybookHomeViewModel
 
+    // MARK: - Navigation State
+
+    @State private var showSections = false
+
     // MARK: - Reorder State
 
     @State private var draggingTaskId: String? = nil
@@ -63,7 +67,7 @@ struct PlaybookHomeView: View {
                     }
 
                     Button {
-                        // Sections placeholder — Issue #25
+                        showSections = true
                     } label: {
                         Label("Sections", systemImage: "doc.text")
                     }
@@ -73,6 +77,12 @@ struct PlaybookHomeView: View {
                 }
                 .accessibilityLabel("More options")
             }
+        }
+        .navigationDestination(isPresented: $showSections) {
+            SectionsListView(vm: SectionsViewModel(
+                playbook: vm.playbook,
+                sectionService: vm.sectionService
+            ))
         }
         .sheet(item: $vm.selectedTask) { task in
             TaskDetailSheet(

--- a/idea-pilot/idea-pilotTests/SectionsViewModelTests.swift
+++ b/idea-pilot/idea-pilotTests/SectionsViewModelTests.swift
@@ -1,0 +1,257 @@
+//
+//  SectionsViewModelTests.swift
+//  idea-pilotTests
+//
+//  Unit tests for SectionsViewModel with mock SectionService.
+//
+
+import Foundation
+import Testing
+@testable import idea_pilot
+
+// MARK: - Mock Section Service
+
+final class MockSectionService: SectionServiceProtocol, @unchecked Sendable {
+
+    nonisolated(unsafe) var fetchResult: Result<[SectionModel], SectionError> = .success([])
+    nonisolated(unsafe) var updateResult: Result<SectionModel, SectionError> = .success(
+        SectionModel(playbookId: "pb-1", sectionType: .vision, content: "Updated")
+    )
+
+    nonisolated(unsafe) var fetchCallCount = 0
+    nonisolated(unsafe) var updateCallCount = 0
+    nonisolated(unsafe) var capturedUpdatePlaybookId: String?
+    nonisolated(unsafe) var capturedUpdateSectionType: SectionType?
+    nonisolated(unsafe) var capturedUpdateContent: String?
+
+    nonisolated func fetchSections(playbookId: String, updatedSince: Date?) async throws -> [SectionModel] {
+        fetchCallCount += 1
+        return try fetchResult.get()
+    }
+
+    nonisolated func updateSection(playbookId: String, sectionType: SectionType, content: String) async throws -> SectionModel {
+        updateCallCount += 1
+        capturedUpdatePlaybookId = playbookId
+        capturedUpdateSectionType = sectionType
+        capturedUpdateContent = content
+        return try updateResult.get()
+    }
+}
+
+// MARK: - Test Helpers
+
+private func makeSampleSections() -> [SectionModel] {
+    [
+        SectionModel(playbookId: "pb-1", sectionType: .vision, content: "Our vision is to build great products"),
+        SectionModel(playbookId: "pb-1", sectionType: .system, content: "Daily standups"),
+        SectionModel(playbookId: "pb-1", sectionType: .build, content: ""),
+        SectionModel(playbookId: "pb-1", sectionType: .businessModel, content: "Freemium model"),
+    ]
+}
+
+private func makePlaybook() -> PlaybookModel {
+    PlaybookModel(id: "pb-1", title: "Test Playbook")
+}
+
+// MARK: - Tests
+
+@Suite("SectionsViewModel", .serialized)
+struct SectionsViewModelTests {
+
+    // MARK: - Load
+
+    @Test("loadSections fetches and populates sections")
+    @MainActor func loadSectionsSuccess() async throws {
+        let service = MockSectionService()
+        service.fetchResult = .success(makeSampleSections())
+        let vm = SectionsViewModel(playbook: makePlaybook(), sectionService: service)
+
+        vm.loadSections()
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(service.fetchCallCount == 1)
+        #expect(vm.sections.count == 4)
+        #expect(vm.error == nil)
+        #expect(vm.isLoading == false)
+    }
+
+    @Test("loadSections network error sets error string")
+    @MainActor func loadSectionsError() async throws {
+        let service = MockSectionService()
+        service.fetchResult = .failure(.networkError("timeout"))
+        let vm = SectionsViewModel(playbook: makePlaybook(), sectionService: service)
+
+        vm.loadSections()
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(vm.error == "Network error. Please check your connection.")
+        #expect(vm.sections.isEmpty)
+        #expect(vm.isLoading == false)
+    }
+
+    // MARK: - Ordered Sections
+
+    @Test("orderedSections returns sections in canonical SectionType order")
+    @MainActor func orderedSections() {
+        let service = MockSectionService()
+        let vm = SectionsViewModel(playbook: makePlaybook(), sectionService: service)
+        // Insert in reverse order.
+        vm.sections = [
+            SectionModel(playbookId: "pb-1", sectionType: .businessModel, content: "BM"),
+            SectionModel(playbookId: "pb-1", sectionType: .vision, content: "V"),
+            SectionModel(playbookId: "pb-1", sectionType: .build, content: "B"),
+            SectionModel(playbookId: "pb-1", sectionType: .system, content: "S"),
+        ]
+
+        let ordered = vm.orderedSections
+        #expect(ordered.count == 4)
+        #expect(ordered[0].sectionType == .vision)
+        #expect(ordered[1].sectionType == .system)
+        #expect(ordered[2].sectionType == .build)
+        #expect(ordered[3].sectionType == .businessModel)
+    }
+
+    // MARK: - Preview Text
+
+    @Test("previewText returns first line of content")
+    @MainActor func previewTextFirstLine() {
+        let service = MockSectionService()
+        let vm = SectionsViewModel(playbook: makePlaybook(), sectionService: service)
+        let section = SectionModel(playbookId: "pb-1", sectionType: .vision, content: "First line\nSecond line\nThird line")
+
+        #expect(vm.previewText(for: section) == "First line")
+    }
+
+    @Test("previewText returns placeholder for empty content")
+    @MainActor func previewTextEmpty() {
+        let service = MockSectionService()
+        let vm = SectionsViewModel(playbook: makePlaybook(), sectionService: service)
+        let section = SectionModel(playbookId: "pb-1", sectionType: .build, content: "")
+
+        #expect(vm.previewText(for: section) == "No content yet")
+    }
+
+    // MARK: - Editor State
+
+    @Test("startEditing sets editingSection and editorContent")
+    @MainActor func startEditing() {
+        let service = MockSectionService()
+        let vm = SectionsViewModel(playbook: makePlaybook(), sectionService: service)
+        let section = SectionModel(playbookId: "pb-1", sectionType: .vision, content: "Vision text")
+
+        vm.startEditing(section)
+
+        #expect(vm.editingSection?.compositeId == section.compositeId)
+        #expect(vm.editorContent == "Vision text")
+    }
+
+    // MARK: - Word and Character Count
+
+    @Test("wordCount and characterCount compute correctly")
+    @MainActor func counts() {
+        let service = MockSectionService()
+        let vm = SectionsViewModel(playbook: makePlaybook(), sectionService: service)
+
+        vm.editorContent = "Hello world foo"
+        #expect(vm.wordCount == 3)
+        #expect(vm.characterCount == 15)
+    }
+
+    @Test("wordCount returns 0 for empty or whitespace-only content")
+    @MainActor func countsEmpty() {
+        let service = MockSectionService()
+        let vm = SectionsViewModel(playbook: makePlaybook(), sectionService: service)
+
+        vm.editorContent = ""
+        #expect(vm.wordCount == 0)
+        #expect(vm.characterCount == 0)
+
+        vm.editorContent = "   \n  "
+        #expect(vm.wordCount == 0)
+    }
+
+    // MARK: - Debounced Save
+
+    @Test("saveContent updates model immediately but debounces API call")
+    @MainActor func saveContentDebounce() async throws {
+        let service = MockSectionService()
+        let vm = SectionsViewModel(playbook: makePlaybook(), sectionService: service)
+        let section = SectionModel(playbookId: "pb-1", sectionType: .vision, content: "Old")
+        vm.sections = [section]
+        vm.startEditing(section)
+
+        vm.editorContent = "New content"
+        vm.saveContent()
+
+        // Model updated immediately.
+        #expect(section.content == "New content")
+
+        // API not called yet.
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(service.updateCallCount == 0)
+
+        // Wait for debounce.
+        try await Task.sleep(for: .milliseconds(1100))
+        #expect(service.updateCallCount == 1)
+        #expect(service.capturedUpdateContent == "New content")
+        #expect(service.capturedUpdateSectionType == .vision)
+    }
+
+    @Test("saveContent cancels previous debounce on rapid changes")
+    @MainActor func saveContentCancelsPrevious() async throws {
+        let service = MockSectionService()
+        let vm = SectionsViewModel(playbook: makePlaybook(), sectionService: service)
+        let section = SectionModel(playbookId: "pb-1", sectionType: .vision, content: "Old")
+        vm.sections = [section]
+        vm.startEditing(section)
+
+        vm.editorContent = "First"
+        vm.saveContent()
+        try await Task.sleep(for: .milliseconds(500))
+
+        vm.editorContent = "Second"
+        vm.saveContent()
+        try await Task.sleep(for: .milliseconds(500))
+
+        // Only 500ms since last call, no API calls yet.
+        #expect(service.updateCallCount == 0)
+
+        // Wait for second debounce to complete.
+        try await Task.sleep(for: .milliseconds(700))
+        #expect(service.updateCallCount == 1)
+        #expect(service.capturedUpdateContent == "Second")
+    }
+
+    // MARK: - Save Error
+
+    @Test("saveContent error sets error string after debounce")
+    @MainActor func saveContentError() async throws {
+        let service = MockSectionService()
+        service.updateResult = .failure(.serverError("Server error"))
+        let vm = SectionsViewModel(playbook: makePlaybook(), sectionService: service)
+        let section = SectionModel(playbookId: "pb-1", sectionType: .vision, content: "Old")
+        vm.sections = [section]
+        vm.startEditing(section)
+
+        vm.editorContent = "New content"
+        vm.saveContent()
+
+        try await Task.sleep(for: .milliseconds(1200))
+        #expect(vm.error != nil)
+    }
+
+    // MARK: - Refresh
+
+    @Test("refresh calls fetch and updates list")
+    @MainActor func refreshSuccess() async throws {
+        let service = MockSectionService()
+        service.fetchResult = .success(makeSampleSections())
+        let vm = SectionsViewModel(playbook: makePlaybook(), sectionService: service)
+
+        await vm.refresh()
+
+        #expect(service.fetchCallCount == 1)
+        #expect(vm.sections.count == 4)
+        #expect(vm.error == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `SectionsListView` displaying the 4 playbook sections (Vision, System, Build, Business Model) as card-style rows with icon, name, and first-line content preview
- Add `SectionEditorView` — full-screen TextEditor with placeholder overlay, live word/character count, debounced auto-save (1s), and immediate flush on disappear
- Add `SectionsViewModel` managing list fetch, editor state, debounced save, and refresh
- Wire the Sections button in `PlaybookHomeView` overflow menu via `@State` + `.navigationDestination(isPresented:)`
- 12 unit tests covering load, order, preview text, editor state, counts, debounce, cancellation, error handling, and refresh

Closes #25

## Test plan
- [ ] Verify `SectionsListView` shows 4 rows in canonical order (Vision → System → Build → Business Model)
- [ ] Verify tapping a row navigates to `SectionEditorView` with correct content
- [ ] Verify typing in editor updates word/character count live
- [ ] Verify auto-save fires after 1s debounce (rapid typing resets timer)
- [ ] Verify navigating back flushes unsaved content immediately
- [ ] Verify pull-to-refresh reloads sections
- [ ] Verify error banner appears on network failure
- [ ] All 199 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)