### PR TITLE
feat: WeeklyPlanService — fetch and update weekly plans (#26)

### DIFF
--- a/idea-pilot/idea-pilot/App/idea_pilotApp.swift
+++ b/idea-pilot/idea-pilot/App/idea_pilotApp.swift
@@ -25,6 +25,7 @@ struct idea_pilotApp: App {
     let playbookService: PlaybookService
     let taskService: TaskService
     let sectionService: SectionService
+    let weeklyPlanService: WeeklyPlanService
 
     init() {
         let container = try! ModelContainer(for: PlaybookModel.self)
@@ -45,6 +46,7 @@ struct idea_pilotApp: App {
         let playbooks = PlaybookService(apiClient: client, modelContainer: container)
         let tasks = TaskService(apiClient: client, modelContainer: container)
         let sections = SectionService(apiClient: client, modelContainer: container)
+        let weeklyPlan = WeeklyPlanService(apiClient: client, modelContainer: container)
 
         self.modelContainer = container
         self.tokenManager = tm
@@ -53,11 +55,12 @@ struct idea_pilotApp: App {
         self.playbookService = playbooks
         self.taskService = tasks
         self.sectionService = sections
+        self.weeklyPlanService = weeklyPlan
     }
 
     var body: some Scene {
         WindowGroup {
-            RootView(tokenManager: tokenManager, authService: authService, playbookService: playbookService, taskService: taskService, sectionService: sectionService)
+            RootView(tokenManager: tokenManager, authService: authService, playbookService: playbookService, taskService: taskService, sectionService: sectionService, weeklyPlanService: weeklyPlanService)
         }
         .modelContainer(modelContainer)
     }

--- a/idea-pilot/idea-pilot/Core/Networking/DTOs/WeeklyCycleDTO.swift
+++ b/idea-pilot/idea-pilot/Core/Networking/DTOs/WeeklyCycleDTO.swift
@@ -18,6 +18,11 @@ nonisolated struct WeeklyCycleDTO: Codable, Sendable {
     let updatedAt: Date
 }
 
+/// Request body for creating a weekly plan.
+nonisolated struct CreateWeeklyPlanDTO: Codable, Sendable {
+    let taskIds: [String]
+}
+
 // MARK: - Mapping
 
 extension WeeklyCycleDTO {

--- a/idea-pilot/idea-pilot/Core/Networking/Endpoint.swift
+++ b/idea-pilot/idea-pilot/Core/Networking/Endpoint.swift
@@ -170,4 +170,12 @@ extension Endpoint {
     static func getWeeklyCycles(playbookId: String) -> Endpoint {
         Endpoint(path: "/v1/playbooks/\(playbookId)/weekly-cycles", method: .get)
     }
+
+    static func getWeeklyStatus(playbookId: String) -> Endpoint {
+        Endpoint(path: "/v1/playbooks/\(playbookId)/weekly/status", method: .get)
+    }
+
+    static func createWeeklyPlan(playbookId: String, dto: CreateWeeklyPlanDTO) -> Endpoint {
+        Endpoint(path: "/v1/playbooks/\(playbookId)/weekly/plan", method: .post, body: dto)
+    }
 }

--- a/idea-pilot/idea-pilot/Features/Playbooks/Views/PlaybookListView.swift
+++ b/idea-pilot/idea-pilot/Features/Playbooks/Views/PlaybookListView.swift
@@ -21,6 +21,7 @@ struct PlaybookListView: View {
     @Bindable var vm: PlaybookListViewModel
     let taskService: any TaskServiceProtocol
     let sectionService: any SectionServiceProtocol
+    let weeklyPlanService: any WeeklyPlanServiceProtocol
 
     var body: some View {
         ScrollView {
@@ -71,6 +72,7 @@ struct PlaybookListView: View {
                     playbook: playbook,
                     taskService: taskService,
                     sectionService: sectionService,
+                    weeklyPlanService: weeklyPlanService,
                     onArchive: { vm.archivePlaybook(id: playbook.id) }
                 )
             }
@@ -128,6 +130,7 @@ private struct PlaybookCardRow: View {
     let playbook: PlaybookModel
     let taskService: any TaskServiceProtocol
     let sectionService: any SectionServiceProtocol
+    let weeklyPlanService: any WeeklyPlanServiceProtocol
     let onArchive: () -> Void
 
     private var nowTaskCount: Int {
@@ -136,7 +139,7 @@ private struct PlaybookCardRow: View {
 
     var body: some View {
         NavigationLink {
-            PlaybookHomeView(vm: PlaybookHomeViewModel(playbook: playbook, taskService: taskService, sectionService: sectionService))
+            PlaybookHomeView(vm: PlaybookHomeViewModel(playbook: playbook, taskService: taskService, sectionService: sectionService, weeklyPlanService: weeklyPlanService))
         } label: {
             HStack(spacing: 12) {
                 VStack(alignment: .leading, spacing: 8) {
@@ -411,7 +414,8 @@ private struct CreatePlaybookSheet: View {
                 return vm
             }(),
             taskService: PlaybookListPreviewTaskService(),
-            sectionService: PlaybookListPreviewSectionService()
+            sectionService: PlaybookListPreviewSectionService(),
+            weeklyPlanService: PlaybookListPreviewWeeklyPlanService()
         )
     }
 }
@@ -421,7 +425,8 @@ private struct CreatePlaybookSheet: View {
         PlaybookListView(
             vm: PlaybookListViewModel(playbookService: PlaybookListPreviewPlaybookService()),
             taskService: PlaybookListPreviewTaskService(),
-            sectionService: PlaybookListPreviewSectionService()
+            sectionService: PlaybookListPreviewSectionService(),
+            weeklyPlanService: PlaybookListPreviewWeeklyPlanService()
         )
     }
 }
@@ -435,7 +440,8 @@ private struct CreatePlaybookSheet: View {
                 return vm
             }(),
             taskService: PlaybookListPreviewTaskService(),
-            sectionService: PlaybookListPreviewSectionService()
+            sectionService: PlaybookListPreviewSectionService(),
+            weeklyPlanService: PlaybookListPreviewWeeklyPlanService()
         )
     }
 }
@@ -455,6 +461,17 @@ private struct PlaybookListPreviewSectionService: SectionServiceProtocol {
     func updateSection(playbookId: String, sectionType: SectionType, content: String) async throws -> SectionModel {
         SectionModel(playbookId: playbookId, sectionType: sectionType, content: content)
     }
+}
+
+/// A no-op weekly plan service for SwiftUI previews.
+private struct PlaybookListPreviewWeeklyPlanService: WeeklyPlanServiceProtocol {
+    func getWeeklyStatus(playbookId: String) async throws -> WeeklyCycleModel {
+        WeeklyCycleModel(playbookId: playbookId, weekStartDate: .now)
+    }
+    func createWeeklyPlan(playbookId: String, taskIds: [String]) async throws -> WeeklyCycleModel {
+        WeeklyCycleModel(playbookId: playbookId, weekStartDate: .now, totalCount: taskIds.count)
+    }
+    func fetchWeeklyCycles(playbookId: String) async throws -> [WeeklyCycleModel] { [] }
 }
 
 /// A no-op task service for SwiftUI previews.

--- a/idea-pilot/idea-pilot/Features/Tasks/ViewModels/PlaybookHomeViewModel.swift
+++ b/idea-pilot/idea-pilot/Features/Tasks/ViewModels/PlaybookHomeViewModel.swift
@@ -73,6 +73,7 @@ final class PlaybookHomeViewModel {
 
     let taskService: any TaskServiceProtocol
     let sectionService: any SectionServiceProtocol
+    let weeklyPlanService: any WeeklyPlanServiceProtocol
 
     // MARK: - Init
 
@@ -82,10 +83,12 @@ final class PlaybookHomeViewModel {
     ///   - playbook: The playbook whose tasks are managed.
     ///   - taskService: The service for task API calls and persistence.
     ///   - sectionService: The service for section API calls and persistence.
-    init(playbook: PlaybookModel, taskService: any TaskServiceProtocol, sectionService: any SectionServiceProtocol) {
+    ///   - weeklyPlanService: The service for weekly plan API calls and persistence.
+    init(playbook: PlaybookModel, taskService: any TaskServiceProtocol, sectionService: any SectionServiceProtocol, weeklyPlanService: any WeeklyPlanServiceProtocol) {
         self.playbook = playbook
         self.taskService = taskService
         self.sectionService = sectionService
+        self.weeklyPlanService = weeklyPlanService
     }
 
     // MARK: - Actions

--- a/idea-pilot/idea-pilot/Features/Tasks/Views/PlaybookHomeView.swift
+++ b/idea-pilot/idea-pilot/Features/Tasks/Views/PlaybookHomeView.swift
@@ -662,7 +662,8 @@ private struct EmptyLaneView: View {
             let vm = PlaybookHomeViewModel(
                 playbook: PlaybookModel(id: "pb-1", title: "Side Hustle App", phase: .proof),
                 taskService: PreviewTaskService(),
-                sectionService: PreviewSectionService()
+                sectionService: PreviewSectionService(),
+                weeklyPlanService: PreviewWeeklyPlanService()
             )
             vm.allTasks = [
                 TaskModel(id: "t-1", playbookId: "pb-1", title: "Research competitors", lane: .now, estimatedMinutes: 90, orderIndex: 0),
@@ -680,7 +681,8 @@ private struct EmptyLaneView: View {
         PlaybookHomeView(vm: PlaybookHomeViewModel(
             playbook: PlaybookModel(id: "pb-1", title: "Empty Playbook"),
             taskService: PreviewTaskService(),
-            sectionService: PreviewSectionService()
+            sectionService: PreviewSectionService(),
+            weeklyPlanService: PreviewWeeklyPlanService()
         ))
     }
 }
@@ -691,6 +693,17 @@ private struct PreviewSectionService: SectionServiceProtocol {
     func updateSection(playbookId: String, sectionType: SectionType, content: String) async throws -> SectionModel {
         SectionModel(playbookId: playbookId, sectionType: sectionType, content: content)
     }
+}
+
+/// A no-op weekly plan service for SwiftUI previews.
+private struct PreviewWeeklyPlanService: WeeklyPlanServiceProtocol {
+    func getWeeklyStatus(playbookId: String) async throws -> WeeklyCycleModel {
+        WeeklyCycleModel(playbookId: playbookId, weekStartDate: .now)
+    }
+    func createWeeklyPlan(playbookId: String, taskIds: [String]) async throws -> WeeklyCycleModel {
+        WeeklyCycleModel(playbookId: playbookId, weekStartDate: .now, totalCount: taskIds.count)
+    }
+    func fetchWeeklyCycles(playbookId: String) async throws -> [WeeklyCycleModel] { [] }
 }
 
 /// A no-op task service for SwiftUI previews.

--- a/idea-pilot/idea-pilot/Features/WeeklyPlan/Services/WeeklyPlanService.swift
+++ b/idea-pilot/idea-pilot/Features/WeeklyPlan/Services/WeeklyPlanService.swift
@@ -1,0 +1,179 @@
+//
+//  WeeklyPlanService.swift
+//  idea-pilot
+//
+//  Service handling weekly plan API calls and SwiftData persistence.
+//  Supports fetching weekly cycles, getting status, and creating plans.
+//
+
+import Foundation
+import SwiftData
+
+// MARK: - WeeklyPlanError
+
+/// Errors specific to weekly plan operations.
+nonisolated enum WeeklyPlanError: Error, Equatable, Sendable {
+    /// The requested resource was not found (404).
+    case notFound
+    /// A network-level failure occurred.
+    case networkError(String)
+    /// The server returned an unexpected error.
+    case serverError(String)
+}
+
+// MARK: - WeeklyPlanServiceProtocol
+
+/// Defines the weekly plan API surface for testability.
+nonisolated protocol WeeklyPlanServiceProtocol: Sendable {
+    /// Fetches the current week's completion status for a playbook.
+    func getWeeklyStatus(playbookId: String) async throws -> WeeklyCycleModel
+
+    /// Creates a weekly plan by promoting the given tasks to Now.
+    func createWeeklyPlan(playbookId: String, taskIds: [String]) async throws -> WeeklyCycleModel
+
+    /// Fetches all weekly cycles for a playbook.
+    /// Falls back to cached SwiftData data when offline.
+    func fetchWeeklyCycles(playbookId: String) async throws -> [WeeklyCycleModel]
+}
+
+// MARK: - WeeklyPlanService
+
+/// Coordinates weekly plan operations through `APIClient` and SwiftData.
+///
+/// Each operation follows the standard pattern:
+/// Call the API → update SwiftData → return model(s).
+///
+/// `fetchWeeklyCycles` supports offline fallback by reading from SwiftData cache
+/// when the network is unavailable.
+final class WeeklyPlanService: WeeklyPlanServiceProtocol, Sendable {
+
+    private let apiClient: APIClient
+    private let modelContainer: ModelContainer
+
+    /// Creates a WeeklyPlanService.
+    ///
+    /// - Parameters:
+    ///   - apiClient: The networking client for API calls.
+    ///   - modelContainer: The SwiftData container for local persistence.
+    init(apiClient: APIClient, modelContainer: ModelContainer) {
+        self.apiClient = apiClient
+        self.modelContainer = modelContainer
+    }
+
+    func getWeeklyStatus(playbookId: String) async throws -> WeeklyCycleModel {
+        do {
+            let dto: WeeklyCycleDTO = try await apiClient.request(
+                .getWeeklyStatus(playbookId: playbookId)
+            )
+            return try await upsertSingleCycle(dto)
+        } catch let error as APIError {
+            throw mapError(error)
+        } catch let error as WeeklyPlanError {
+            throw error
+        } catch {
+            throw WeeklyPlanError.serverError(error.localizedDescription)
+        }
+    }
+
+    func createWeeklyPlan(playbookId: String, taskIds: [String]) async throws -> WeeklyCycleModel {
+        do {
+            let dto = CreateWeeklyPlanDTO(taskIds: taskIds)
+            let response: WeeklyCycleDTO = try await apiClient.request(
+                .createWeeklyPlan(playbookId: playbookId, dto: dto)
+            )
+            return try await upsertSingleCycle(response)
+        } catch let error as APIError {
+            throw mapError(error)
+        } catch let error as WeeklyPlanError {
+            throw error
+        } catch {
+            throw WeeklyPlanError.serverError(error.localizedDescription)
+        }
+    }
+
+    func fetchWeeklyCycles(playbookId: String) async throws -> [WeeklyCycleModel] {
+        do {
+            let dtos: [WeeklyCycleDTO] = try await apiClient.request(
+                .getWeeklyCycles(playbookId: playbookId)
+            )
+            return try await upsertCycles(dtos)
+        } catch let error as APIError {
+            if error.isOffline {
+                return try await cachedWeeklyCycles(playbookId: playbookId)
+            }
+            throw mapError(error)
+        } catch let error as WeeklyPlanError {
+            throw error
+        } catch {
+            throw WeeklyPlanError.serverError(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Private — SwiftData Operations
+
+    /// Upserts an array of weekly cycle DTOs into SwiftData.
+    @MainActor
+    private func upsertCycles(_ dtos: [WeeklyCycleDTO]) throws -> [WeeklyCycleModel] {
+        let context = modelContainer.mainContext
+        var models: [WeeklyCycleModel] = []
+
+        for dto in dtos {
+            let cycleId = dto.id
+
+            let predicate = #Predicate<WeeklyCycleModel> { $0.id == cycleId }
+            var descriptor = FetchDescriptor(predicate: predicate)
+            descriptor.fetchLimit = 1
+
+            if let existing = try context.fetch(descriptor).first {
+                existing.completedCount = dto.completedCount
+                existing.totalCount = dto.totalCount
+                existing.weekStartDate = dto.weekStartDate
+                existing.updatedAt = dto.updatedAt
+                models.append(existing)
+            } else {
+                let model = dto.toModel()
+                context.insert(model)
+                models.append(model)
+            }
+        }
+
+        try context.save()
+        return models
+    }
+
+    /// Upserts a single weekly cycle DTO into SwiftData.
+    @MainActor
+    private func upsertSingleCycle(_ dto: WeeklyCycleDTO) throws -> WeeklyCycleModel {
+        try upsertCycles([dto]).first!
+    }
+
+    /// Returns cached weekly cycles from SwiftData (offline fallback).
+    @MainActor
+    private func cachedWeeklyCycles(playbookId: String) throws -> [WeeklyCycleModel] {
+        let context = modelContainer.mainContext
+        let predicate = #Predicate<WeeklyCycleModel> { $0.playbookId == playbookId }
+        let descriptor = FetchDescriptor(predicate: predicate)
+        return try context.fetch(descriptor)
+    }
+
+    // MARK: - Private — Error Mapping
+
+    private func mapError(_ error: APIError) -> WeeklyPlanError {
+        switch error {
+        case .notFound:
+            return .notFound
+        case .networkError(let urlError):
+            return .networkError(urlError.localizedDescription)
+        case .offline:
+            return .networkError("No internet connection")
+        case .serverError(_, let message):
+            return .serverError(message ?? "Server error")
+        case .badRequest(let message):
+            return .serverError(message ?? "Bad request")
+        case .sessionExpired:
+            return .serverError("Session expired")
+        case .decodingError(let message):
+            return .serverError("Invalid response: \(message)")
+        }
+    }
+}

--- a/idea-pilot/idea-pilot/Navigation/MainTabView.swift
+++ b/idea-pilot/idea-pilot/Navigation/MainTabView.swift
@@ -59,16 +59,18 @@ struct MainTabView: View {
     let taskService: any TaskServiceProtocol
     let playbookService: any PlaybookServiceProtocol
     let sectionService: any SectionServiceProtocol
+    let weeklyPlanService: any WeeklyPlanServiceProtocol
 
     @State private var selectedTab: AppTab = .now
     @State private var playbookListVM: PlaybookListViewModel
     @State private var showQuickAddSheet = false
 
-    init(playbookService: any PlaybookServiceProtocol, taskService: any TaskServiceProtocol, sectionService: any SectionServiceProtocol, onSignOut: @escaping () -> Void) {
+    init(playbookService: any PlaybookServiceProtocol, taskService: any TaskServiceProtocol, sectionService: any SectionServiceProtocol, weeklyPlanService: any WeeklyPlanServiceProtocol, onSignOut: @escaping () -> Void) {
         self.onSignOut = onSignOut
         self.taskService = taskService
         self.playbookService = playbookService
         self.sectionService = sectionService
+        self.weeklyPlanService = weeklyPlanService
         self._playbookListVM = State(initialValue: PlaybookListViewModel(playbookService: playbookService))
     }
 
@@ -105,7 +107,7 @@ struct MainTabView: View {
             .opacity(selectedTab == .now ? 1 : 0)
 
             NavigationStack {
-                PlaybookListView(vm: playbookListVM, taskService: taskService, sectionService: sectionService)
+                PlaybookListView(vm: playbookListVM, taskService: taskService, sectionService: sectionService, weeklyPlanService: weeklyPlanService)
             }
             .opacity(selectedTab == .playbooks ? 1 : 0)
         }
@@ -223,6 +225,7 @@ private struct NowPlaceholderView: View {
         playbookService: MainTabPreviewPlaybookService(),
         taskService: MainTabPreviewTaskService(),
         sectionService: MainTabPreviewSectionService(),
+        weeklyPlanService: MainTabPreviewWeeklyPlanService(),
         onSignOut: {}
     )
 }
@@ -242,6 +245,17 @@ private struct MainTabPreviewSectionService: SectionServiceProtocol {
     func updateSection(playbookId: String, sectionType: SectionType, content: String) async throws -> SectionModel {
         SectionModel(playbookId: playbookId, sectionType: sectionType, content: content)
     }
+}
+
+/// A no-op weekly plan service for MainTabView previews.
+private struct MainTabPreviewWeeklyPlanService: WeeklyPlanServiceProtocol {
+    func getWeeklyStatus(playbookId: String) async throws -> WeeklyCycleModel {
+        WeeklyCycleModel(playbookId: playbookId, weekStartDate: .now)
+    }
+    func createWeeklyPlan(playbookId: String, taskIds: [String]) async throws -> WeeklyCycleModel {
+        WeeklyCycleModel(playbookId: playbookId, weekStartDate: .now, totalCount: taskIds.count)
+    }
+    func fetchWeeklyCycles(playbookId: String) async throws -> [WeeklyCycleModel] { [] }
 }
 
 /// A no-op task service for MainTabView previews.

--- a/idea-pilot/idea-pilot/Navigation/RootView.swift
+++ b/idea-pilot/idea-pilot/Navigation/RootView.swift
@@ -22,6 +22,7 @@ struct RootView: View {
     let playbookService: any PlaybookServiceProtocol
     let taskService: any TaskServiceProtocol
     let sectionService: any SectionServiceProtocol
+    let weeklyPlanService: any WeeklyPlanServiceProtocol
 
     @State private var isAuthenticated = false
     @State private var isCheckingAuth = true
@@ -32,7 +33,7 @@ struct RootView: View {
             if isCheckingAuth {
                 splashView
             } else if isAuthenticated {
-                MainTabView(playbookService: playbookService, taskService: taskService, sectionService: sectionService, onSignOut: signOut)
+                MainTabView(playbookService: playbookService, taskService: taskService, sectionService: sectionService, weeklyPlanService: weeklyPlanService, onSignOut: signOut)
             } else if let vm = authViewModel {
                 AuthView(vm: vm)
             }

--- a/idea-pilot/idea-pilotTests/PlaybookHomeViewModelTests.swift
+++ b/idea-pilot/idea-pilotTests/PlaybookHomeViewModelTests.swift
@@ -94,6 +94,19 @@ private final class StubSectionService: SectionServiceProtocol, @unchecked Senda
     }
 }
 
+// MARK: - Stub Weekly Plan Service
+
+/// Minimal stub for WeeklyPlanServiceProtocol used when tests don't exercise weekly plan logic.
+private final class StubWeeklyPlanService: WeeklyPlanServiceProtocol, @unchecked Sendable {
+    nonisolated func getWeeklyStatus(playbookId: String) async throws -> WeeklyCycleModel {
+        WeeklyCycleModel(playbookId: playbookId, weekStartDate: .now)
+    }
+    nonisolated func createWeeklyPlan(playbookId: String, taskIds: [String]) async throws -> WeeklyCycleModel {
+        WeeklyCycleModel(playbookId: playbookId, weekStartDate: .now, totalCount: taskIds.count)
+    }
+    nonisolated func fetchWeeklyCycles(playbookId: String) async throws -> [WeeklyCycleModel] { [] }
+}
+
 // MARK: - Test Helpers
 
 private func makeSamplePlaybook() -> PlaybookModel {
@@ -127,7 +140,7 @@ struct PlaybookHomeViewModelTests {
     @MainActor func loadTasksSuccess() async throws {
         let mockService = MockTaskService()
         mockService.fetchResult = .success(makeSampleTasks())
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService(), weeklyPlanService: StubWeeklyPlanService())
 
         vm.loadTasks()
         try await Task.sleep(for: .milliseconds(50))
@@ -142,7 +155,7 @@ struct PlaybookHomeViewModelTests {
     @MainActor func loadTasksError() async throws {
         let mockService = MockTaskService()
         mockService.fetchResult = .failure(.networkError("timeout"))
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService(), weeklyPlanService: StubWeeklyPlanService())
 
         vm.loadTasks()
         try await Task.sleep(for: .milliseconds(50))
@@ -158,7 +171,7 @@ struct PlaybookHomeViewModelTests {
     @MainActor func refreshCallsFetch() async throws {
         let mockService = MockTaskService()
         mockService.fetchResult = .success(makeSampleTasks())
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService(), weeklyPlanService: StubWeeklyPlanService())
 
         await vm.refresh()
 
@@ -172,7 +185,7 @@ struct PlaybookHomeViewModelTests {
     @Test("tasksInCurrentLane returns only NOW tasks by default")
     @MainActor func laneFilteringNow() {
         let mockService = MockTaskService()
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService(), weeklyPlanService: StubWeeklyPlanService())
         vm.allTasks = makeSampleTasks()
 
         let nowTasks = vm.tasksInCurrentLane
@@ -183,7 +196,7 @@ struct PlaybookHomeViewModelTests {
     @Test("selectLane switches to NEXT and filters correctly")
     @MainActor func laneFilteringNext() {
         let mockService = MockTaskService()
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService(), weeklyPlanService: StubWeeklyPlanService())
         vm.allTasks = makeSampleTasks()
 
         vm.selectLane(.next)
@@ -196,7 +209,7 @@ struct PlaybookHomeViewModelTests {
     @Test("tasksInCurrentLane excludes completed tasks")
     @MainActor func laneFilteringHidesDone() {
         let mockService = MockTaskService()
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService(), weeklyPlanService: StubWeeklyPlanService())
         vm.allTasks = makeMixedStatusTasks()
 
         let tasks = vm.tasksInCurrentLane
@@ -207,7 +220,7 @@ struct PlaybookHomeViewModelTests {
     @Test("taskCounts returns correct counts per lane")
     @MainActor func taskCountsPerLane() {
         let mockService = MockTaskService()
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService(), weeklyPlanService: StubWeeklyPlanService())
         vm.allTasks = makeSampleTasks()
 
         let counts = vm.taskCounts
@@ -224,7 +237,7 @@ struct PlaybookHomeViewModelTests {
         let completedTask = TaskModel(id: "t-1", playbookId: "pb-1", title: "Now Task 1", lane: .now, status: .done, completedAt: .now)
         mockService.completeResult = .success(completedTask)
 
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService(), weeklyPlanService: StubWeeklyPlanService())
         vm.allTasks = makeSampleTasks()
 
         vm.completeTask(id: "t-1")
@@ -241,7 +254,7 @@ struct PlaybookHomeViewModelTests {
         let mockService = MockTaskService()
         mockService.completeResult = .failure(.serverError("Server error"))
 
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService(), weeklyPlanService: StubWeeklyPlanService())
         vm.allTasks = makeSampleTasks()
 
         vm.completeTask(id: "t-1")
@@ -258,7 +271,7 @@ struct PlaybookHomeViewModelTests {
         let movedTask = TaskModel(id: "t-1", playbookId: "pb-1", title: "Now Task 1", lane: .next, orderIndex: 0)
         mockService.updateResult = .success(movedTask)
 
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService(), weeklyPlanService: StubWeeklyPlanService())
         vm.allTasks = makeSampleTasks()
 
         vm.moveTask(id: "t-1", toLane: .next)
@@ -276,7 +289,7 @@ struct PlaybookHomeViewModelTests {
     @Test("reorderTasks updates local orderIndex and calls service")
     @MainActor func reorderTasksSuccess() async throws {
         let mockService = MockTaskService()
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService(), weeklyPlanService: StubWeeklyPlanService())
         vm.allTasks = makeSampleTasks()
 
         // Reverse the order of NOW tasks.
@@ -299,7 +312,7 @@ struct PlaybookHomeViewModelTests {
     @Test("emptyStateMessage returns correct message per lane")
     @MainActor func emptyStateMessages() {
         let mockService = MockTaskService()
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService(), weeklyPlanService: StubWeeklyPlanService())
 
         vm.selectLane(.now)
         #expect(vm.emptyStateMessage == "No active tasks. Move a task to Now to get started.")
@@ -316,7 +329,7 @@ struct PlaybookHomeViewModelTests {
     @Test("selectTask and clearSelectedTask manage detail sheet state")
     @MainActor func selectAndClearTask() {
         let mockService = MockTaskService()
-        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService())
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: mockService, sectionService: StubSectionService(), weeklyPlanService: StubWeeklyPlanService())
         let task = TaskModel(playbookId: "pb-1", title: "Test Task")
 
         vm.selectTask(task)

--- a/idea-pilot/idea-pilotTests/WeeklyPlanServiceTests.swift
+++ b/idea-pilot/idea-pilotTests/WeeklyPlanServiceTests.swift
@@ -1,0 +1,325 @@
+//
+//  WeeklyPlanServiceTests.swift
+//  idea-pilotTests
+//
+//  Unit tests for WeeklyPlanService with mock networking and in-memory SwiftData.
+//
+
+import Foundation
+import SwiftData
+import Testing
+@testable import idea_pilot
+
+// MARK: - Mock URL Protocol
+
+/// A `URLProtocol` subclass for WeeklyPlanService tests, independent of other mocks.
+final class WeeklyPlanMockURLProtocol: URLProtocol, @unchecked Sendable {
+
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> (Data, HTTPURLResponse))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = WeeklyPlanMockURLProtocol.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+
+        do {
+            let (data, response) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Test Helpers
+
+private let testBaseURL = URL(string: "https://api.test.ideapilot.app")!
+
+private func makeURLSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [WeeklyPlanMockURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+private nonisolated func makeResponse(statusCode: Int) -> HTTPURLResponse {
+    HTTPURLResponse(
+        url: testBaseURL,
+        statusCode: statusCode,
+        httpVersion: nil,
+        headerFields: nil
+    )!
+}
+
+private nonisolated func makeInMemoryModelContainer() throws -> ModelContainer {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    return try ModelContainer(
+        for: PlaybookModel.self, TaskModel.self, SectionModel.self, WeeklyCycleModel.self,
+        configurations: config
+    )
+}
+
+private nonisolated func makeWeeklyPlanService(
+    session: URLSession? = nil
+) throws -> (WeeklyPlanService, ModelContainer) {
+    let urlSession = session ?? makeURLSession()
+    let apiClient = APIClient(baseURL: testBaseURL, session: urlSession)
+    let container = try makeInMemoryModelContainer()
+    let service = WeeklyPlanService(apiClient: apiClient, modelContainer: container)
+    return (service, container)
+}
+
+// MARK: - Mock JSON Fixtures
+
+private let weeklyStatusJSON = #"""
+{
+    "id": "wc-1",
+    "playbook_id": "pb-1",
+    "week_start_date": "2025-06-02T00:00:00Z",
+    "completed_count": 3,
+    "total_count": 5,
+    "created_at": "2025-06-02T00:00:00Z",
+    "updated_at": "2025-06-04T00:00:00Z"
+}
+"""#
+
+private let weeklyPlanResponseJSON = #"""
+{
+    "id": "wc-2",
+    "playbook_id": "pb-1",
+    "week_start_date": "2025-06-09T00:00:00Z",
+    "completed_count": 0,
+    "total_count": 3,
+    "created_at": "2025-06-09T00:00:00Z",
+    "updated_at": "2025-06-09T00:00:00Z"
+}
+"""#
+
+private let weeklyCyclesArrayJSON = #"""
+[
+    {
+        "id": "wc-1",
+        "playbook_id": "pb-1",
+        "week_start_date": "2025-06-02T00:00:00Z",
+        "completed_count": 3,
+        "total_count": 5,
+        "created_at": "2025-06-02T00:00:00Z",
+        "updated_at": "2025-06-04T00:00:00Z"
+    },
+    {
+        "id": "wc-2",
+        "playbook_id": "pb-1",
+        "week_start_date": "2025-06-09T00:00:00Z",
+        "completed_count": 0,
+        "total_count": 3,
+        "created_at": "2025-06-09T00:00:00Z",
+        "updated_at": "2025-06-09T00:00:00Z"
+    }
+]
+"""#
+
+// MARK: - Tests
+
+@Suite("WeeklyPlanService", .serialized)
+struct WeeklyPlanServiceTests {
+
+    // MARK: - Get Weekly Status
+
+    @Test("getWeeklyStatus decodes and upserts into SwiftData")
+    func getWeeklyStatusSuccess() async throws {
+        WeeklyPlanMockURLProtocol.handler = { _ in
+            (Data(weeklyStatusJSON.utf8), makeResponse(statusCode: 200))
+        }
+        let (service, container) = try makeWeeklyPlanService()
+
+        let model = try await service.getWeeklyStatus(playbookId: "pb-1")
+
+        #expect(model.id == "wc-1")
+        #expect(model.completedCount == 3)
+        #expect(model.totalCount == 5)
+        #expect(model.playbookId == "pb-1")
+
+        // Verify persisted in SwiftData.
+        let context = await container.mainContext
+        let descriptor = FetchDescriptor<WeeklyCycleModel>()
+        let persisted = try await context.fetch(descriptor)
+        #expect(persisted.count == 1)
+        #expect(persisted.first?.completedCount == 3)
+
+        WeeklyPlanMockURLProtocol.handler = nil
+    }
+
+    @Test("getWeeklyStatus server error throws WeeklyPlanError.serverError")
+    func getWeeklyStatusServerError() async throws {
+        let errorJSON = #"{"message":"Internal server error"}"#
+        WeeklyPlanMockURLProtocol.handler = { _ in
+            (Data(errorJSON.utf8), makeResponse(statusCode: 500))
+        }
+        let (service, _) = try makeWeeklyPlanService()
+
+        do {
+            _ = try await service.getWeeklyStatus(playbookId: "pb-1")
+            Issue.record("Expected WeeklyPlanError.serverError")
+        } catch let error as WeeklyPlanError {
+            guard case .serverError = error else {
+                Issue.record("Expected serverError, got \(error)")
+                return
+            }
+        }
+
+        WeeklyPlanMockURLProtocol.handler = nil
+    }
+
+    // MARK: - Create Weekly Plan
+
+    @Test("createWeeklyPlan sends POST with task IDs and upserts response")
+    func createWeeklyPlanSuccess() async throws {
+        nonisolated(unsafe) var capturedMethod: String?
+        nonisolated(unsafe) var capturedPath: String?
+        nonisolated(unsafe) var capturedBody: Data?
+
+        WeeklyPlanMockURLProtocol.handler = { request in
+            capturedMethod = request.httpMethod
+            capturedPath = request.url?.path
+            capturedBody = request.httpBodyStreamData ?? request.httpBody
+            return (Data(weeklyPlanResponseJSON.utf8), makeResponse(statusCode: 200))
+        }
+
+        let (service, container) = try makeWeeklyPlanService()
+
+        let model = try await service.createWeeklyPlan(
+            playbookId: "pb-1",
+            taskIds: ["t-1", "t-2", "t-3"]
+        )
+
+        #expect(capturedMethod == "POST")
+        #expect(capturedPath?.contains("/v1/playbooks/pb-1/weekly/plan") == true)
+        #expect(model.totalCount == 3)
+        #expect(model.completedCount == 0)
+
+        // Verify persisted in SwiftData.
+        let context = await container.mainContext
+        let descriptor = FetchDescriptor<WeeklyCycleModel>()
+        let persisted = try await context.fetch(descriptor)
+        #expect(persisted.count == 1)
+
+        WeeklyPlanMockURLProtocol.handler = nil
+    }
+
+    @Test("createWeeklyPlan bad request throws WeeklyPlanError.serverError")
+    func createWeeklyPlanBadRequest() async throws {
+        let errorJSON = #"{"message":"Task selection required"}"#
+        WeeklyPlanMockURLProtocol.handler = { _ in
+            (Data(errorJSON.utf8), makeResponse(statusCode: 400))
+        }
+        let (service, _) = try makeWeeklyPlanService()
+
+        do {
+            _ = try await service.createWeeklyPlan(playbookId: "pb-1", taskIds: [])
+            Issue.record("Expected WeeklyPlanError.serverError")
+        } catch let error as WeeklyPlanError {
+            guard case .serverError = error else {
+                Issue.record("Expected serverError, got \(error)")
+                return
+            }
+        }
+
+        WeeklyPlanMockURLProtocol.handler = nil
+    }
+
+    // MARK: - Fetch Weekly Cycles
+
+    @Test("fetchWeeklyCycles decodes array and upserts into SwiftData")
+    func fetchWeeklyCyclesSuccess() async throws {
+        WeeklyPlanMockURLProtocol.handler = { _ in
+            (Data(weeklyCyclesArrayJSON.utf8), makeResponse(statusCode: 200))
+        }
+        let (service, container) = try makeWeeklyPlanService()
+
+        let models = try await service.fetchWeeklyCycles(playbookId: "pb-1")
+
+        #expect(models.count == 2)
+        #expect(models.contains { $0.id == "wc-1" && $0.completedCount == 3 })
+        #expect(models.contains { $0.id == "wc-2" && $0.totalCount == 3 })
+
+        // Verify persisted in SwiftData.
+        let context = await container.mainContext
+        let descriptor = FetchDescriptor<WeeklyCycleModel>()
+        let persisted = try await context.fetch(descriptor)
+        #expect(persisted.count == 2)
+
+        WeeklyPlanMockURLProtocol.handler = nil
+    }
+
+    @Test("fetchWeeklyCycles falls back to SwiftData cache when offline")
+    func fetchWeeklyCyclesOfflineFallback() async throws {
+        let (service, container) = try makeWeeklyPlanService()
+
+        // Pre-populate cache.
+        let context = await container.mainContext
+        let cached = WeeklyCycleModel(id: "wc-cached", playbookId: "pb-1", weekStartDate: .now, completedCount: 2, totalCount: 4)
+        await context.insert(cached)
+        try await context.save()
+
+        // Simulate offline.
+        WeeklyPlanMockURLProtocol.handler = { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+
+        let models = try await service.fetchWeeklyCycles(playbookId: "pb-1")
+        #expect(models.count == 1)
+        #expect(models.first?.id == "wc-cached")
+        #expect(models.first?.completedCount == 2)
+
+        WeeklyPlanMockURLProtocol.handler = nil
+    }
+
+    @Test("fetchWeeklyCycles server error throws WeeklyPlanError.serverError")
+    func fetchWeeklyCyclesServerError() async throws {
+        let errorJSON = #"{"message":"Internal server error"}"#
+        WeeklyPlanMockURLProtocol.handler = { _ in
+            (Data(errorJSON.utf8), makeResponse(statusCode: 500))
+        }
+        let (service, _) = try makeWeeklyPlanService()
+
+        do {
+            _ = try await service.fetchWeeklyCycles(playbookId: "pb-1")
+            Issue.record("Expected WeeklyPlanError.serverError")
+        } catch let error as WeeklyPlanError {
+            guard case .serverError = error else {
+                Issue.record("Expected serverError, got \(error)")
+                return
+            }
+        }
+
+        WeeklyPlanMockURLProtocol.handler = nil
+    }
+}
+
+// MARK: - URLRequest httpBodyStreamData Helper
+
+private extension URLRequest {
+    /// Reads the httpBodyStream into Data (used when httpBody is nil but stream exists).
+    var httpBodyStreamData: Data? {
+        guard let stream = httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let bufferSize = 1024
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let bytesRead = stream.read(buffer, maxLength: bufferSize)
+            guard bytesRead > 0 else { break }
+            data.append(buffer, count: bytesRead)
+        }
+        return data.isEmpty ? nil : data
+    }
+}


### PR DESCRIPTION
## Summary
- Add `WeeklyPlanService` with protocol, error enum, and implementation following `SectionService` pattern
- Add `getWeeklyStatus` (GET), `createWeeklyPlan` (POST with task IDs), and `fetchWeeklyCycles` (GET with offline fallback) endpoints
- Add `CreateWeeklyPlanDTO` request body and two new endpoints in `Endpoint.swift`
- Thread `weeklyPlanService` through full DI chain: App → RootView → MainTabView → PlaybookListView → PlaybookHomeViewModel
- 7 unit tests covering success, error, upsert, and offline fallback scenarios

Closes #26

## Test plan
- [ ] Verify `getWeeklyStatus` decodes response and upserts into SwiftData
- [ ] Verify `createWeeklyPlan` sends POST with task IDs and returns upserted model
- [ ] Verify `fetchWeeklyCycles` returns cached data when offline
- [ ] Verify error mapping for 400, 404, and 500 status codes
- [ ] All 206+ tests pass locally (7 new WeeklyPlanService tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)