### PR TITLE
feat: SyncEngine — mutation queue and background sync (#29)

### DIFF
--- a/idea-pilot/idea-pilot/App/idea_pilotApp.swift
+++ b/idea-pilot/idea-pilot/App/idea_pilotApp.swift
@@ -26,9 +26,10 @@ struct idea_pilotApp: App {
     let taskService: TaskService
     let sectionService: SectionService
     let weeklyPlanService: WeeklyPlanService
+    let syncEngine: SyncEngine
 
     init() {
-        let container = try! ModelContainer(for: PlaybookModel.self)
+        let container = try! ModelContainer(for: PlaybookModel.self, MutationEntry.self)
         let tm = TokenManager(
             keychain: KeychainService(),
             baseURL: AppConfiguration.apiBaseURL
@@ -43,24 +44,36 @@ struct idea_pilotApp: App {
             modelContainer: container
         )
 
-        let playbooks = PlaybookService(apiClient: client, modelContainer: container)
-        let tasks = TaskService(apiClient: client, modelContainer: container)
-        let sections = SectionService(apiClient: client, modelContainer: container)
-        let weeklyPlan = WeeklyPlanService(apiClient: client, modelContainer: container)
+        let sync = SyncEngine(apiClient: client, modelContainer: container)
+
+        let playbooks = PlaybookService(apiClient: client, modelContainer: container, syncEngine: sync)
+        let tasks = TaskService(apiClient: client, modelContainer: container, syncEngine: sync)
+        let sections = SectionService(apiClient: client, modelContainer: container, syncEngine: sync)
+        let weeklyPlan = WeeklyPlanService(apiClient: client, modelContainer: container, syncEngine: sync)
 
         self.modelContainer = container
         self.tokenManager = tm
         self.apiClient = client
         self.authService = auth
+        self.syncEngine = sync
         self.playbookService = playbooks
         self.taskService = tasks
         self.sectionService = sections
         self.weeklyPlanService = weeklyPlan
+
+        sync.start()
     }
+
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some Scene {
         WindowGroup {
-            RootView(tokenManager: tokenManager, authService: authService, playbookService: playbookService, taskService: taskService, sectionService: sectionService, weeklyPlanService: weeklyPlanService)
+            RootView(tokenManager: tokenManager, authService: authService, playbookService: playbookService, taskService: taskService, sectionService: sectionService, weeklyPlanService: weeklyPlanService, syncEngine: syncEngine)
+                .onChange(of: scenePhase) { _, newPhase in
+                    if newPhase == .active {
+                        syncEngine.onAppForeground()
+                    }
+                }
         }
         .modelContainer(modelContainer)
     }

--- a/idea-pilot/idea-pilot/Core/Networking/APIClient.swift
+++ b/idea-pilot/idea-pilot/Core/Networking/APIClient.swift
@@ -78,6 +78,74 @@ final class APIClient: Sendable {
         try mapErrorStatus(statusCode, data: data)
     }
 
+    // MARK: - Mutation Replay
+
+    /// Replays a queued mutation with pre-encoded body data.
+    ///
+    /// Used by `SyncEngine` to drain the mutation queue. Body data was
+    /// pre-encoded at enqueue time (snake_case + ISO8601) so it is injected
+    /// directly without re-encoding.
+    ///
+    /// Includes full auth handling (token injection + 401 refresh-and-retry).
+    ///
+    /// - Parameters:
+    ///   - path: The endpoint path (e.g., `"/v1/tasks"`).
+    ///   - method: The HTTP method.
+    ///   - bodyData: Pre-encoded JSON body data, or `nil`.
+    ///   - requiresAuth: Whether to inject the Bearer token.
+    /// - Returns: The raw response `Data`.
+    /// - Throws: `APIError` on failure.
+    func replayMutation(
+        path: String,
+        method: HTTPMethod,
+        bodyData: Data?,
+        requiresAuth: Bool = true
+    ) async throws -> Data {
+        let endpoint = Endpoint(path: path, method: method, requiresAuth: requiresAuth)
+        var request = try await buildURLRequest(for: endpoint)
+
+        // Override body with pre-encoded data (already snake_case + ISO8601).
+        if let bodyData {
+            request.httpBody = bodyData
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+
+        let (data, response) = try await performRequest(request)
+
+        #if DEBUG
+        logRequest(request, statusCode: response.statusCode, data: data)
+        #endif
+
+        // Handle 401 with token refresh and retry.
+        if response.statusCode == 401 && requiresAuth {
+            guard let provider = tokenProvider else {
+                throw APIError.sessionExpired
+            }
+            do {
+                try await provider.refresh()
+            } catch {
+                await provider.clearTokens()
+                throw APIError.sessionExpired
+            }
+            var retryRequest = try await buildURLRequest(for: endpoint)
+            if let bodyData {
+                retryRequest.httpBody = bodyData
+                retryRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            }
+            let (retryData, retryResponse) = try await performRequest(retryRequest)
+
+            #if DEBUG
+            logRequest(retryRequest, statusCode: retryResponse.statusCode, data: retryData)
+            #endif
+
+            try mapErrorStatus(retryResponse.statusCode, data: retryData)
+            return retryData
+        }
+
+        try mapErrorStatus(response.statusCode, data: data)
+        return data
+    }
+
     // MARK: - Private
 
     private func buildURLRequest(for endpoint: Endpoint) async throws -> URLRequest {

--- a/idea-pilot/idea-pilot/Core/Sync/MutationEntry.swift
+++ b/idea-pilot/idea-pilot/Core/Sync/MutationEntry.swift
@@ -1,0 +1,105 @@
+//
+//  MutationEntry.swift
+//  idea-pilot
+//
+//  SwiftData model representing a queued offline mutation.
+//  Each entry stores enough information to replay the API request
+//  when connectivity is restored.
+//
+
+import Foundation
+import SwiftData
+
+// MARK: - MutationStatus
+
+/// The lifecycle state of a queued mutation.
+nonisolated enum MutationStatus: String, Sendable {
+    /// Waiting to be sent.
+    case pending
+    /// Currently being sent by the SyncEngine.
+    case inFlight
+}
+
+// MARK: - MutationEntry
+
+/// A queued offline mutation persisted in SwiftData.
+///
+/// Stores the endpoint path, HTTP method, pre-encoded JSON body,
+/// entity metadata, and retry state. The `SyncEngine` drains these
+/// entries in FIFO order (by `createdAt`) when connectivity is available.
+///
+/// Body data is pre-encoded at enqueue time using snake_case + ISO8601
+/// to match the API contract, avoiding double-encoding on replay.
+@Model
+final class MutationEntry {
+
+    /// Unique identifier for this queue entry.
+    @Attribute(.unique) var id: String
+
+    /// The API endpoint path (e.g., `"/v1/tasks"`).
+    var endpointPath: String
+
+    /// The HTTP method raw value (e.g., `"POST"`, `"PATCH"`).
+    var httpMethodRawValue: String
+
+    /// Pre-encoded JSON request body, or `nil` for bodyless requests.
+    var bodyData: Data?
+
+    /// The domain entity type (e.g., `"task"`, `"playbook"`, `"section"`).
+    var entityType: String
+
+    /// The entity ID (server ID for updates/deletes, temp ID for creates).
+    var entityId: String?
+
+    /// Number of failed replay attempts.
+    var retryCount: Int
+
+    /// Maximum allowed retries before the entry is discarded.
+    var maxRetries: Int
+
+    /// Timestamp of creation, used for FIFO ordering.
+    var createdAt: Date
+
+    /// Timestamp of the last replay attempt, used for backoff calculation.
+    var lastAttemptAt: Date?
+
+    /// Current lifecycle state raw value.
+    var statusRawValue: String
+
+    /// The current lifecycle state.
+    var status: MutationStatus {
+        get { MutationStatus(rawValue: statusRawValue) ?? .pending }
+        set { statusRawValue = newValue.rawValue }
+    }
+
+    /// The HTTP method.
+    var httpMethod: HTTPMethod {
+        HTTPMethod(rawValue: httpMethodRawValue) ?? .post
+    }
+
+    init(
+        id: String = UUID().uuidString,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        bodyData: Data? = nil,
+        entityType: String,
+        entityId: String? = nil,
+        retryCount: Int = 0,
+        maxRetries: Int = 5,
+        createdAt: Date = .now,
+        lastAttemptAt: Date? = nil,
+        status: MutationStatus = .pending
+    ) {
+        self.id = id
+        self.endpointPath = endpointPath
+        self.httpMethodRawValue = httpMethod.rawValue
+        self.bodyData = bodyData
+        self.entityType = entityType
+        self.entityId = entityId
+        self.retryCount = retryCount
+        self.maxRetries = maxRetries
+        self.createdAt = createdAt
+        self.lastAttemptAt = lastAttemptAt
+        self.statusRawValue = status.rawValue
+    }
+}

--- a/idea-pilot/idea-pilot/Core/Sync/MutationQueue.swift
+++ b/idea-pilot/idea-pilot/Core/Sync/MutationQueue.swift
@@ -1,0 +1,168 @@
+//
+//  MutationQueue.swift
+//  idea-pilot
+//
+//  Persistent FIFO queue of offline mutations backed by SwiftData.
+//  All mutations are stored as MutationEntry models in the same
+//  ModelContainer used by the rest of the app. The queue persists
+//  across app launches.
+//
+
+import Foundation
+import SwiftData
+
+/// A persistent FIFO queue of offline mutations backed by SwiftData.
+///
+/// The `SyncEngine` drives this queue: enqueuing mutations when services
+/// detect offline conditions, and draining entries when connectivity
+/// is available.
+///
+/// All SwiftData operations run on `@MainActor` (project default).
+@Observable
+final class MutationQueue {
+
+    private let modelContainer: ModelContainer
+
+    /// The number of pending mutations in the queue (observable by views).
+    var pendingCount: Int = 0
+
+    /// Creates a MutationQueue.
+    ///
+    /// - Parameter modelContainer: The SwiftData container for persistence.
+    init(modelContainer: ModelContainer) {
+        self.modelContainer = modelContainer
+    }
+
+    // MARK: - Enqueue
+
+    /// Enqueues a mutation for later replay.
+    ///
+    /// - Parameters:
+    ///   - path: The API endpoint path.
+    ///   - method: The HTTP method.
+    ///   - bodyData: Pre-encoded JSON body data.
+    ///   - entityType: The domain entity type (e.g., "task").
+    ///   - entityId: Optional entity ID for reconciliation.
+    func enqueue(
+        path: String,
+        method: HTTPMethod,
+        bodyData: Data?,
+        entityType: String,
+        entityId: String?
+    ) throws {
+        let context = modelContainer.mainContext
+        let entry = MutationEntry(
+            endpointPath: path,
+            httpMethod: method,
+            bodyData: bodyData,
+            entityType: entityType,
+            entityId: entityId
+        )
+        context.insert(entry)
+        try context.save()
+        refreshPendingCount()
+    }
+
+    // MARK: - Peek / Fetch
+
+    /// Returns the next pending mutation in FIFO order, or `nil` if empty.
+    func peek() throws -> MutationEntry? {
+        let context = modelContainer.mainContext
+        let statusRaw = MutationStatus.pending.rawValue
+        let predicate = #Predicate<MutationEntry> { $0.statusRawValue == statusRaw }
+        var descriptor = FetchDescriptor(predicate: predicate, sortBy: [SortDescriptor(\.createdAt)])
+        descriptor.fetchLimit = 1
+        return try context.fetch(descriptor).first
+    }
+
+    /// Returns all pending mutations in FIFO order.
+    func allPending() throws -> [MutationEntry] {
+        let context = modelContainer.mainContext
+        let statusRaw = MutationStatus.pending.rawValue
+        let predicate = #Predicate<MutationEntry> { $0.statusRawValue == statusRaw }
+        let descriptor = FetchDescriptor(predicate: predicate, sortBy: [SortDescriptor(\.createdAt)])
+        return try context.fetch(descriptor)
+    }
+
+    // MARK: - State Transitions
+
+    /// Marks a mutation as in-flight (currently being sent).
+    func markInFlight(_ entry: MutationEntry) throws {
+        entry.status = .inFlight
+        try modelContainer.mainContext.save()
+    }
+
+    /// Removes a successfully sent mutation from the queue.
+    func remove(_ entry: MutationEntry) throws {
+        let context = modelContainer.mainContext
+        context.delete(entry)
+        try context.save()
+        refreshPendingCount()
+    }
+
+    /// Marks a mutation as failed and increments its retry count.
+    ///
+    /// If the retry count exceeds `maxRetries`, the entry is permanently
+    /// removed from the queue (discarded).
+    func markFailed(_ entry: MutationEntry) throws {
+        entry.retryCount += 1
+        entry.lastAttemptAt = .now
+        if entry.retryCount >= entry.maxRetries {
+            let context = modelContainer.mainContext
+            context.delete(entry)
+            try context.save()
+        } else {
+            entry.status = .pending
+            try modelContainer.mainContext.save()
+        }
+        refreshPendingCount()
+    }
+
+    // MARK: - Recovery
+
+    /// Resets any in-flight mutations back to pending.
+    ///
+    /// Called at app launch to recover from a crash during drain.
+    /// Entries that were mid-flight when the app terminated are
+    /// returned to the pending state for retry.
+    func resetInFlightToPending() throws {
+        let context = modelContainer.mainContext
+        let statusRaw = MutationStatus.inFlight.rawValue
+        let predicate = #Predicate<MutationEntry> { $0.statusRawValue == statusRaw }
+        let descriptor = FetchDescriptor(predicate: predicate)
+        let stale = try context.fetch(descriptor)
+        for entry in stale {
+            entry.status = .pending
+        }
+        if !stale.isEmpty {
+            try context.save()
+        }
+        refreshPendingCount()
+    }
+
+    /// Removes all entries from the queue.
+    ///
+    /// Called on sign-out to clear any pending mutations.
+    func purge() throws {
+        let context = modelContainer.mainContext
+        let descriptor = FetchDescriptor<MutationEntry>()
+        let all = try context.fetch(descriptor)
+        for entry in all {
+            context.delete(entry)
+        }
+        if !all.isEmpty {
+            try context.save()
+        }
+        pendingCount = 0
+    }
+
+    // MARK: - Private
+
+    private func refreshPendingCount() {
+        let context = modelContainer.mainContext
+        let statusRaw = MutationStatus.pending.rawValue
+        let predicate = #Predicate<MutationEntry> { $0.statusRawValue == statusRaw }
+        let descriptor = FetchDescriptor(predicate: predicate)
+        pendingCount = (try? context.fetchCount(descriptor)) ?? 0
+    }
+}

--- a/idea-pilot/idea-pilot/Core/Sync/NetworkMonitor.swift
+++ b/idea-pilot/idea-pilot/Core/Sync/NetworkMonitor.swift
@@ -1,0 +1,67 @@
+//
+//  NetworkMonitor.swift
+//  idea-pilot
+//
+//  Wraps NWPathMonitor to provide observable connectivity state.
+//  The SyncEngine uses this to trigger queue drains when
+//  connectivity is restored and to gate drain attempts.
+//
+
+import Foundation
+import Network
+
+/// Observable wrapper around `NWPathMonitor` for network reachability.
+///
+/// Runs the monitor on a dedicated background queue. The `isConnected`
+/// property is updated on the MainActor so SwiftUI views can observe it.
+///
+/// When connectivity is restored after being offline, the
+/// `onConnectivityRestored` callback fires (used by `SyncEngine` to
+/// trigger a drain).
+///
+/// Usage:
+/// ```swift
+/// let monitor = NetworkMonitor()
+/// monitor.onConnectivityRestored = { syncEngine.triggerDrain() }
+/// monitor.start()
+/// ```
+@Observable
+final class NetworkMonitor {
+
+    /// Whether the device currently has network connectivity.
+    var isConnected: Bool = true
+
+    /// Callback invoked on the MainActor when connectivity is restored
+    /// after being offline.
+    var onConnectivityRestored: (() -> Void)?
+
+    private let monitor: NWPathMonitor
+    private let queue: DispatchQueue
+
+    init() {
+        self.monitor = NWPathMonitor()
+        self.queue = DispatchQueue(label: "app.ideapilot.networkmonitor")
+    }
+
+    /// Starts monitoring network connectivity. Call once at app launch.
+    func start() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            Task { @MainActor in
+                guard let self else { return }
+                let wasConnected = self.isConnected
+                let nowConnected = path.status == .satisfied
+                self.isConnected = nowConnected
+
+                if !wasConnected && nowConnected {
+                    self.onConnectivityRestored?()
+                }
+            }
+        }
+        monitor.start(queue: queue)
+    }
+
+    /// Stops monitoring. Call on sign-out or app termination.
+    func stop() {
+        monitor.cancel()
+    }
+}

--- a/idea-pilot/idea-pilot/Core/Sync/SyncEngine.swift
+++ b/idea-pilot/idea-pilot/Core/Sync/SyncEngine.swift
@@ -1,0 +1,348 @@
+//
+//  SyncEngine.swift
+//  idea-pilot
+//
+//  Orchestrates offline mutation queueing, background drain, and sync status.
+//  Services call `enqueue()` when they detect offline conditions on write operations.
+//  The engine drains the queue when connectivity is restored, the app foregrounds,
+//  pull-to-refresh fires, or after a mutation (debounced 2s).
+//
+
+import Foundation
+import SwiftData
+
+/// The core offline-first sync orchestrator.
+///
+/// Coordinates between the `MutationQueue`, `NetworkMonitor`, and `APIClient`
+/// to ensure offline mutations are persisted and replayed when connectivity
+/// is available.
+///
+/// ## Drain Logic
+/// 1. Entries are processed in FIFO order (by `createdAt`).
+/// 2. Each entry is marked in-flight, then replayed via `APIClient.replayMutation()`.
+/// 3. On success: POST creates are reconciled (temp ID → server ID), then the entry is removed.
+/// 4. On retryable failure (offline, 500+): entry is marked failed with incremented retry count.
+/// 5. On non-retryable failure (400, 404, session expired): entry is discarded.
+///
+/// ## Backoff
+/// Failed entries use exponential backoff: `min(2^retryCount * 1s, 60s)`.
+/// After `maxRetries` (default 5), the entry is permanently discarded.
+@Observable
+final class SyncEngine: @unchecked Sendable {
+
+    // MARK: - Public State
+
+    /// Observable sync status for UI indicators.
+    let status: SyncStatus
+
+    /// Observable network connectivity state.
+    let networkMonitor: NetworkMonitor
+
+    /// The persistent mutation queue.
+    let mutationQueue: MutationQueue
+
+    // MARK: - Dependencies
+
+    private let apiClient: APIClient
+    private let modelContainer: ModelContainer
+
+    // MARK: - Configuration
+
+    private let baseDelay: TimeInterval = 1.0
+    private let maxDelay: TimeInterval = 60.0
+    private let mutationDebounceInterval: TimeInterval = 2.0
+
+    // MARK: - Internal State
+
+    private var isDraining = false
+    private var debounceTask: Task<Void, Never>?
+
+    /// JSON decoder matching the API contract (snake_case + ISO8601).
+    private let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+
+    /// JSON encoder matching the API contract (snake_case + ISO8601).
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+
+    // MARK: - Init
+
+    /// Creates a SyncEngine.
+    ///
+    /// - Parameters:
+    ///   - apiClient: The networking client for replaying mutations.
+    ///   - modelContainer: The SwiftData container (shared with services).
+    init(apiClient: APIClient, modelContainer: ModelContainer) {
+        self.apiClient = apiClient
+        self.modelContainer = modelContainer
+        self.status = SyncStatus()
+        self.networkMonitor = NetworkMonitor()
+        self.mutationQueue = MutationQueue(modelContainer: modelContainer)
+    }
+
+    // MARK: - Lifecycle
+
+    /// Starts the sync engine. Call once at app launch.
+    ///
+    /// Starts the network monitor, recovers any stale in-flight entries
+    /// from a previous crash, and triggers an initial drain if connected.
+    func start() {
+        networkMonitor.onConnectivityRestored = { [weak self] in
+            self?.triggerDrain()
+        }
+        networkMonitor.start()
+
+        Task {
+            try? mutationQueue.resetInFlightToPending()
+            updateStatus()
+            if networkMonitor.isConnected {
+                triggerDrain()
+            }
+        }
+    }
+
+    /// Stops the sync engine. Call on sign-out.
+    ///
+    /// Stops the network monitor and purges the mutation queue.
+    func stop() {
+        networkMonitor.stop()
+        debounceTask?.cancel()
+        debounceTask = nil
+        try? mutationQueue.purge()
+        status.value = .synced
+    }
+
+    // MARK: - Enqueue
+
+    /// Enqueues a mutation for later replay.
+    ///
+    /// Called by services when they catch `APIError.offline` or `.networkError`
+    /// on a write operation. The mutation is silently added to the persistent
+    /// queue and will be replayed when connectivity returns.
+    ///
+    /// - Parameters:
+    ///   - path: The API endpoint path (e.g., `"/v1/tasks"`).
+    ///   - method: The HTTP method.
+    ///   - body: The Encodable request body (serialized to JSON Data internally).
+    ///   - entityType: The domain entity type (e.g., `"task"`, `"playbook"`).
+    ///   - entityId: Optional entity ID for create reconciliation.
+    func enqueue(
+        path: String,
+        method: HTTPMethod,
+        body: (any Encodable & Sendable)?,
+        entityType: String,
+        entityId: String? = nil
+    ) {
+        let bodyData: Data?
+        if let body {
+            bodyData = try? encoder.encode(body)
+        } else {
+            bodyData = nil
+        }
+
+        do {
+            try mutationQueue.enqueue(
+                path: path,
+                method: method,
+                bodyData: bodyData,
+                entityType: entityType,
+                entityId: entityId
+            )
+            updateStatus()
+        } catch {
+            #if DEBUG
+            print("[SyncEngine] Failed to enqueue mutation: \(error)")
+            #endif
+        }
+    }
+
+    // MARK: - Triggers
+
+    /// Triggers a drain when the app returns to the foreground.
+    func onAppForeground() {
+        guard networkMonitor.isConnected else { return }
+        triggerDrain()
+    }
+
+    /// Triggers a drain from pull-to-refresh. Awaitable so `.refreshable` can use it.
+    func onPullToRefresh() async {
+        guard networkMonitor.isConnected else { return }
+        await drain()
+    }
+
+    /// Triggers a drain after a mutation with a 2-second debounce.
+    ///
+    /// Multiple rapid mutations (e.g., reordering) coalesce into a single drain.
+    func onMutationCompleted() {
+        debounceTask?.cancel()
+        debounceTask = Task {
+            try? await Task.sleep(for: .seconds(mutationDebounceInterval))
+            guard !Task.isCancelled else { return }
+            await drain()
+        }
+    }
+
+    /// Triggers a drain (fire-and-forget).
+    func triggerDrain() {
+        Task { await drain() }
+    }
+
+    // MARK: - Drain Logic
+
+    /// Drains the mutation queue in FIFO order.
+    ///
+    /// Each mutation is replayed through `APIClient.replayMutation()`. On success,
+    /// POST creates are reconciled (temp ID replaced with server ID), then the entry
+    /// is removed. Failed entries are retried with exponential backoff.
+    private func drain() async {
+        guard !isDraining else { return }
+        guard networkMonitor.isConnected else {
+            updateStatus()
+            return
+        }
+
+        isDraining = true
+        status.value = .syncing
+
+        do {
+            while let entry = try mutationQueue.peek() {
+                guard networkMonitor.isConnected else { break }
+
+                // Respect exponential backoff.
+                if let lastAttempt = entry.lastAttemptAt {
+                    let backoff = min(pow(2.0, Double(entry.retryCount)) * baseDelay, maxDelay)
+                    let nextAttemptAt = lastAttempt.addingTimeInterval(backoff)
+                    if Date.now < nextAttemptAt {
+                        break
+                    }
+                }
+
+                try mutationQueue.markInFlight(entry)
+
+                do {
+                    let responseData = try await apiClient.replayMutation(
+                        path: entry.endpointPath,
+                        method: entry.httpMethod,
+                        bodyData: entry.bodyData,
+                        requiresAuth: true
+                    )
+
+                    // Reconcile POST creates (replace temp ID with server ID).
+                    if entry.httpMethodRawValue == HTTPMethod.post.rawValue,
+                       let tempId = entry.entityId {
+                        try await reconcileCreate(
+                            entityType: entry.entityType,
+                            tempId: tempId,
+                            responseData: responseData
+                        )
+                    }
+
+                    try mutationQueue.remove(entry)
+                } catch let error as APIError {
+                    if isRetryable(error) {
+                        try mutationQueue.markFailed(entry)
+                    } else {
+                        // Non-retryable (400, 404, session expired) — discard.
+                        try mutationQueue.remove(entry)
+                    }
+                } catch {
+                    try mutationQueue.markFailed(entry)
+                }
+            }
+        } catch {
+            #if DEBUG
+            print("[SyncEngine] Drain error: \(error)")
+            #endif
+            status.value = .error(error.localizedDescription)
+        }
+
+        isDraining = false
+        updateStatus()
+    }
+
+    // MARK: - Create Reconciliation
+
+    /// Reconciles a successfully replayed POST create mutation.
+    ///
+    /// Deletes the optimistic model (with temp ID) and inserts the
+    /// server-truth model (with real server ID).
+    private func reconcileCreate(entityType: String, tempId: String, responseData: Data) async throws {
+        let context = modelContainer.mainContext
+
+        switch entityType {
+        case "task":
+            let dto = try decoder.decode(TaskDTO.self, from: responseData)
+            let predicate = #Predicate<TaskModel> { $0.id == tempId }
+            var descriptor = FetchDescriptor(predicate: predicate)
+            descriptor.fetchLimit = 1
+            if let temp = try context.fetch(descriptor).first {
+                context.delete(temp)
+            }
+            let model = dto.toModel()
+            context.insert(model)
+            try context.save()
+
+        case "playbook":
+            let dto = try decoder.decode(PlaybookDTO.self, from: responseData)
+            let predicate = #Predicate<PlaybookModel> { $0.id == tempId }
+            var descriptor = FetchDescriptor(predicate: predicate)
+            descriptor.fetchLimit = 1
+            if let temp = try context.fetch(descriptor).first {
+                context.delete(temp)
+            }
+            let model = dto.toModel()
+            context.insert(model)
+            try context.save()
+
+        case "weeklyCycle":
+            let dto = try decoder.decode(WeeklyCycleDTO.self, from: responseData)
+            let predicate = #Predicate<WeeklyCycleModel> { $0.id == tempId }
+            var descriptor = FetchDescriptor(predicate: predicate)
+            descriptor.fetchLimit = 1
+            if let temp = try context.fetch(descriptor).first {
+                context.delete(temp)
+            }
+            let model = dto.toModel()
+            context.insert(model)
+            try context.save()
+
+        default:
+            break
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Determines if an API error is retryable (worth keeping in the queue).
+    private nonisolated func isRetryable(_ error: APIError) -> Bool {
+        switch error {
+        case .offline, .networkError:
+            return true
+        case .serverError(let code, _) where code >= 500:
+            return true
+        case .badRequest, .notFound, .sessionExpired, .decodingError:
+            return false
+        default:
+            return false
+        }
+    }
+
+    /// Updates the sync status based on current queue and connectivity state.
+    private func updateStatus() {
+        if !networkMonitor.isConnected {
+            status.value = .offline
+        } else if mutationQueue.pendingCount > 0 {
+            status.value = .pending(mutationQueue.pendingCount)
+        } else {
+            status.value = .synced
+        }
+    }
+}

--- a/idea-pilot/idea-pilot/Core/Sync/SyncStatus.swift
+++ b/idea-pilot/idea-pilot/Core/Sync/SyncStatus.swift
@@ -1,0 +1,45 @@
+//
+//  SyncStatus.swift
+//  idea-pilot
+//
+//  Observable sync status for UI display.
+//  Views observe `SyncStatus.value` to show sync indicators
+//  (green/synced, yellow/pending, animated/syncing, red/error, grey/offline).
+//
+
+import Foundation
+
+// MARK: - SyncStatusValue
+
+/// The current synchronization state of the mutation queue.
+///
+/// Used by views to display sync indicators:
+/// - `.synced` — all mutations sent, connected (green)
+/// - `.syncing` — drain in progress (animated)
+/// - `.pending(count)` — mutations waiting to send (yellow)
+/// - `.error(message)` — last drain attempt failed (red)
+/// - `.offline` — no network connectivity (grey)
+nonisolated enum SyncStatusValue: Equatable, Sendable {
+    /// Queue is empty and device is connected.
+    case synced
+    /// Currently draining the mutation queue.
+    case syncing
+    /// Mutations are queued and waiting for connectivity or drain.
+    case pending(Int)
+    /// The last drain attempt encountered an error.
+    case error(String)
+    /// Device has no network connectivity.
+    case offline
+}
+
+// MARK: - SyncStatus
+
+/// Observable container for the current sync status.
+///
+/// Any view can observe this to show sync indicators.
+/// Updated by `SyncEngine` as the queue state changes.
+@Observable
+final class SyncStatus {
+    /// The current sync status value.
+    var value: SyncStatusValue = .synced
+}

--- a/idea-pilot/idea-pilot/Features/Playbooks/Services/PlaybookService.swift
+++ b/idea-pilot/idea-pilot/Features/Playbooks/Services/PlaybookService.swift
@@ -51,15 +51,18 @@ final class PlaybookService: PlaybookServiceProtocol, Sendable {
 
     private let apiClient: APIClient
     private let modelContainer: ModelContainer
+    private let syncEngine: SyncEngine?
 
     /// Creates a PlaybookService.
     ///
     /// - Parameters:
     ///   - apiClient: The networking client for API calls.
     ///   - modelContainer: The SwiftData container for local persistence.
-    init(apiClient: APIClient, modelContainer: ModelContainer) {
+    ///   - syncEngine: Optional sync engine for offline mutation queueing.
+    init(apiClient: APIClient, modelContainer: ModelContainer, syncEngine: SyncEngine? = nil) {
         self.apiClient = apiClient
         self.modelContainer = modelContainer
+        self.syncEngine = syncEngine
     }
 
     func fetchPlaybooks(updatedSince: Date? = nil) async throws -> [PlaybookModel] {
@@ -80,14 +83,31 @@ final class PlaybookService: PlaybookServiceProtocol, Sendable {
 
     func createPlaybook(title: String, description: String?) async throws -> PlaybookModel {
         let dto = CreatePlaybookDTO(title: title, description: description, phase: PlaybookPhase.proof.rawValue)
+
+        // Insert optimistically so offline creates appear immediately.
+        let tempModel = try await insertOptimisticPlaybook(title: title, description: description)
+
         do {
             let response: PlaybookDTO = try await apiClient.request(.createPlaybook(dto: dto))
-            return try await insertPlaybook(response)
-        } catch let error as APIError {
+            return try await reconcileCreatedPlaybook(tempId: tempModel.id, dto: response)
+        } catch let error as APIError where error.isOffline {
+            if let syncEngine {
+                await syncEngine.enqueue(
+                    path: "/v1/playbooks",
+                    method: .post,
+                    body: dto,
+                    entityType: "playbook",
+                    entityId: tempModel.id
+                )
+                return tempModel
+            }
+            try await removePlaybook(id: tempModel.id)
             throw mapError(error)
-        } catch let error as PlaybookError {
-            throw error
         } catch {
+            try await removePlaybook(id: tempModel.id)
+            if let apiError = error as? APIError {
+                throw mapError(apiError)
+            }
             throw PlaybookError.serverError(error.localizedDescription)
         }
     }
@@ -96,6 +116,19 @@ final class PlaybookService: PlaybookServiceProtocol, Sendable {
         do {
             try await apiClient.requestVoid(.archivePlaybook(id: id))
             try await markArchived(id: id)
+        } catch let error as APIError where error.isOffline {
+            if let syncEngine {
+                try await markArchived(id: id)
+                await syncEngine.enqueue(
+                    path: "/v1/playbooks/\(id)/archive",
+                    method: .post,
+                    body: nil as CreatePlaybookDTO?,
+                    entityType: "playbook",
+                    entityId: id
+                )
+                return
+            }
+            throw mapError(error)
         } catch let error as APIError {
             throw mapError(error)
         } catch let error as PlaybookError {
@@ -146,6 +179,45 @@ final class PlaybookService: PlaybookServiceProtocol, Sendable {
         context.insert(model)
         try context.save()
         return model
+    }
+
+    /// Inserts an optimistic playbook with a temp ID for offline creates.
+    @MainActor
+    private func insertOptimisticPlaybook(title: String, description: String?) throws -> PlaybookModel {
+        let context = modelContainer.mainContext
+        let model = PlaybookModel(id: UUID().uuidString, title: title, descriptionText: description)
+        context.insert(model)
+        try context.save()
+        return model
+    }
+
+    /// Replaces the optimistic model with the server-truth model.
+    @MainActor
+    private func reconcileCreatedPlaybook(tempId: String, dto: PlaybookDTO) throws -> PlaybookModel {
+        let context = modelContainer.mainContext
+        let predicate = #Predicate<PlaybookModel> { $0.id == tempId }
+        var descriptor = FetchDescriptor(predicate: predicate)
+        descriptor.fetchLimit = 1
+        if let temp = try context.fetch(descriptor).first {
+            context.delete(temp)
+        }
+        let model = dto.toModel()
+        context.insert(model)
+        try context.save()
+        return model
+    }
+
+    /// Removes a playbook from SwiftData (rollback for failed optimistic creates).
+    @MainActor
+    private func removePlaybook(id: String) throws {
+        let context = modelContainer.mainContext
+        let predicate = #Predicate<PlaybookModel> { $0.id == id }
+        var descriptor = FetchDescriptor(predicate: predicate)
+        descriptor.fetchLimit = 1
+        if let model = try context.fetch(descriptor).first {
+            context.delete(model)
+            try context.save()
+        }
     }
 
     /// Marks a playbook as archived in SwiftData.

--- a/idea-pilot/idea-pilot/Features/Sections/Services/SectionService.swift
+++ b/idea-pilot/idea-pilot/Features/Sections/Services/SectionService.swift
@@ -46,15 +46,18 @@ final class SectionService: SectionServiceProtocol, Sendable {
 
     private let apiClient: APIClient
     private let modelContainer: ModelContainer
+    private let syncEngine: SyncEngine?
 
     /// Creates a SectionService.
     ///
     /// - Parameters:
     ///   - apiClient: The networking client for API calls.
     ///   - modelContainer: The SwiftData container for local persistence.
-    init(apiClient: APIClient, modelContainer: ModelContainer) {
+    ///   - syncEngine: Optional sync engine for offline mutation queueing.
+    init(apiClient: APIClient, modelContainer: ModelContainer, syncEngine: SyncEngine? = nil) {
         self.apiClient = apiClient
         self.modelContainer = modelContainer
+        self.syncEngine = syncEngine
     }
 
     func fetchSections(playbookId: String, updatedSince: Date? = nil) async throws -> [SectionModel] {
@@ -76,12 +79,25 @@ final class SectionService: SectionServiceProtocol, Sendable {
     }
 
     func updateSection(playbookId: String, sectionType: SectionType, content: String) async throws -> SectionModel {
+        let dto = UpdateSectionDTO(content: content)
         do {
-            let dto = UpdateSectionDTO(content: content)
             let response: SectionDTO = try await apiClient.request(
                 .updateSection(playbookId: playbookId, sectionType: sectionType.rawValue, dto: dto)
             )
             return try await upsertSingleSection(response)
+        } catch let error as APIError where error.isOffline {
+            if let syncEngine {
+                let model = try await applyLocalSectionUpdate(playbookId: playbookId, sectionType: sectionType, content: content)
+                await syncEngine.enqueue(
+                    path: "/v1/playbooks/\(playbookId)/sections/\(sectionType.rawValue)",
+                    method: .put,
+                    body: dto,
+                    entityType: "section",
+                    entityId: "\(playbookId)_\(sectionType.rawValue)"
+                )
+                return model
+            }
+            throw mapError(error)
         } catch let error as APIError {
             throw mapError(error)
         } catch let error as SectionError {
@@ -125,6 +141,28 @@ final class SectionService: SectionServiceProtocol, Sendable {
     @MainActor
     private func upsertSingleSection(_ dto: SectionDTO) throws -> SectionModel {
         try upsertSections([dto]).first!
+    }
+
+    /// Applies a section content update locally (for offline queueing).
+    @MainActor
+    @discardableResult
+    private func applyLocalSectionUpdate(playbookId: String, sectionType: SectionType, content: String) throws -> SectionModel {
+        let context = modelContainer.mainContext
+        let compositeId = "\(playbookId)_\(sectionType.rawValue)"
+        let predicate = #Predicate<SectionModel> { $0.compositeId == compositeId }
+        var descriptor = FetchDescriptor(predicate: predicate)
+        descriptor.fetchLimit = 1
+        if let existing = try context.fetch(descriptor).first {
+            existing.content = content
+            existing.updatedAt = .now
+            try context.save()
+            return existing
+        } else {
+            let model = SectionModel(playbookId: playbookId, sectionType: sectionType, content: content)
+            context.insert(model)
+            try context.save()
+            return model
+        }
     }
 
     /// Returns cached sections from SwiftData (offline fallback).

--- a/idea-pilot/idea-pilot/Features/Tasks/Services/TaskService.swift
+++ b/idea-pilot/idea-pilot/Features/Tasks/Services/TaskService.swift
@@ -60,15 +60,18 @@ final class TaskService: TaskServiceProtocol, Sendable {
 
     private let apiClient: APIClient
     private let modelContainer: ModelContainer
+    private let syncEngine: SyncEngine?
 
     /// Creates a TaskService.
     ///
     /// - Parameters:
     ///   - apiClient: The networking client for API calls.
     ///   - modelContainer: The SwiftData container for local persistence.
-    init(apiClient: APIClient, modelContainer: ModelContainer) {
+    ///   - syncEngine: Optional sync engine for offline mutation queueing.
+    init(apiClient: APIClient, modelContainer: ModelContainer, syncEngine: SyncEngine? = nil) {
         self.apiClient = apiClient
         self.modelContainer = modelContainer
+        self.syncEngine = syncEngine
     }
 
     func fetchTasks(playbookId: String, lane: TaskLane? = nil, updatedSince: Date? = nil) async throws -> [TaskModel] {
@@ -118,8 +121,22 @@ final class TaskService: TaskServiceProtocol, Sendable {
             let response: TaskDTO = try await apiClient.request(.createTask(dto: dto))
             // 3. On success: reconcile local model with server response.
             return try await reconcileCreatedTask(tempId: tempId, dto: response)
+        } catch let error as APIError where error.isOffline {
+            // 4a. Offline: keep optimistic insert, queue for later sync.
+            if let syncEngine {
+                await syncEngine.enqueue(
+                    path: "/v1/tasks",
+                    method: .post,
+                    body: dto,
+                    entityType: "task",
+                    entityId: tempId
+                )
+                return try await fetchLocalTask(id: tempId)
+            }
+            try await rollbackTask(tempId: tempId)
+            throw mapError(error)
         } catch {
-            // 4. On failure: rollback (delete the optimistic insert).
+            // 4b. Other failure: rollback (delete the optimistic insert).
             try await rollbackTask(tempId: tempId)
             if let apiError = error as? APIError {
                 throw mapError(apiError)
@@ -132,6 +149,19 @@ final class TaskService: TaskServiceProtocol, Sendable {
         do {
             let response: TaskDTO = try await apiClient.request(.updateTask(id: id, dto: dto))
             return try await upsertSingleTask(response)
+        } catch let error as APIError where error.isOffline {
+            if let syncEngine {
+                try await applyLocalTaskUpdate(id: id, dto: dto)
+                await syncEngine.enqueue(
+                    path: "/v1/tasks/\(id)",
+                    method: .patch,
+                    body: dto,
+                    entityType: "task",
+                    entityId: id
+                )
+                return try await fetchLocalTask(id: id)
+            }
+            throw mapError(error)
         } catch let error as APIError {
             throw mapError(error)
         } catch let error as TaskError {
@@ -149,6 +179,20 @@ final class TaskService: TaskServiceProtocol, Sendable {
             let response: TaskDTO = try await apiClient.request(.completeTask(id: id))
             // Reconcile with server response (server sets canonical completedAt).
             return try await upsertSingleTask(response)
+        } catch let error as APIError where error.isOffline {
+            // Offline: keep optimistic completion, queue for later sync.
+            if let syncEngine {
+                await syncEngine.enqueue(
+                    path: "/v1/tasks/\(id)/complete",
+                    method: .post,
+                    body: nil as CreateTaskDTO?,
+                    entityType: "task",
+                    entityId: id
+                )
+                return try await fetchLocalTask(id: id)
+            }
+            try await restoreTaskState(id: id, previousState: previousState)
+            throw mapError(error)
         } catch {
             // Rollback on failure.
             try await restoreTaskState(id: id, previousState: previousState)
@@ -164,6 +208,18 @@ final class TaskService: TaskServiceProtocol, Sendable {
         do {
             try await apiClient.requestVoid(.reorderTasks(dto: dto))
             try await updateLocalOrder(taskIds: taskIds)
+        } catch let error as APIError where error.isOffline {
+            if let syncEngine {
+                try await updateLocalOrder(taskIds: taskIds)
+                await syncEngine.enqueue(
+                    path: "/v1/tasks/reorder",
+                    method: .post,
+                    body: dto,
+                    entityType: "task"
+                )
+                return
+            }
+            throw mapError(error)
         } catch let error as APIError {
             throw mapError(error)
         } catch let error as TaskError {
@@ -177,6 +233,19 @@ final class TaskService: TaskServiceProtocol, Sendable {
         do {
             try await apiClient.requestVoid(.deleteTask(id: id))
             try await removeTask(id: id)
+        } catch let error as APIError where error.isOffline {
+            if let syncEngine {
+                try await removeTask(id: id)
+                await syncEngine.enqueue(
+                    path: "/v1/tasks/\(id)",
+                    method: .delete,
+                    body: nil as CreateTaskDTO?,
+                    entityType: "task",
+                    entityId: id
+                )
+                return
+            }
+            throw mapError(error)
         } catch let error as APIError {
             throw mapError(error)
         } catch let error as TaskError {
@@ -346,6 +415,36 @@ final class TaskService: TaskServiceProtocol, Sendable {
 
         guard let model = try context.fetch(descriptor).first else { return }
         context.delete(model)
+        try context.save()
+    }
+
+    /// Fetches a single task from SwiftData by ID.
+    @MainActor
+    private func fetchLocalTask(id: String) throws -> TaskModel {
+        let context = modelContainer.mainContext
+        let predicate = #Predicate<TaskModel> { $0.id == id }
+        var descriptor = FetchDescriptor(predicate: predicate)
+        descriptor.fetchLimit = 1
+        guard let model = try context.fetch(descriptor).first else {
+            throw TaskError.notFound
+        }
+        return model
+    }
+
+    /// Applies an update DTO to a local task (for offline queueing).
+    @MainActor
+    private func applyLocalTaskUpdate(id: String, dto: UpdateTaskDTO) throws {
+        let context = modelContainer.mainContext
+        let predicate = #Predicate<TaskModel> { $0.id == id }
+        var descriptor = FetchDescriptor(predicate: predicate)
+        descriptor.fetchLimit = 1
+        guard let model = try context.fetch(descriptor).first else { return }
+        if let title = dto.title { model.title = title }
+        if let detail = dto.detail { model.detail = detail }
+        if let lane = dto.lane { model.laneRawValue = lane }
+        if let minutes = dto.estimatedMinutes { model.estimatedMinutes = minutes }
+        if let status = dto.status { model.statusRawValue = status }
+        if let order = dto.orderIndex { model.orderIndex = order }
         try context.save()
     }
 

--- a/idea-pilot/idea-pilot/Features/WeeklyPlan/Services/WeeklyPlanService.swift
+++ b/idea-pilot/idea-pilot/Features/WeeklyPlan/Services/WeeklyPlanService.swift
@@ -49,15 +49,18 @@ final class WeeklyPlanService: WeeklyPlanServiceProtocol, Sendable {
 
     private let apiClient: APIClient
     private let modelContainer: ModelContainer
+    private let syncEngine: SyncEngine?
 
     /// Creates a WeeklyPlanService.
     ///
     /// - Parameters:
     ///   - apiClient: The networking client for API calls.
     ///   - modelContainer: The SwiftData container for local persistence.
-    init(apiClient: APIClient, modelContainer: ModelContainer) {
+    ///   - syncEngine: Optional sync engine for offline mutation queueing.
+    init(apiClient: APIClient, modelContainer: ModelContainer, syncEngine: SyncEngine? = nil) {
         self.apiClient = apiClient
         self.modelContainer = modelContainer
+        self.syncEngine = syncEngine
     }
 
     func getWeeklyStatus(playbookId: String) async throws -> WeeklyCycleModel {
@@ -76,12 +79,25 @@ final class WeeklyPlanService: WeeklyPlanServiceProtocol, Sendable {
     }
 
     func createWeeklyPlan(playbookId: String, taskIds: [String]) async throws -> WeeklyCycleModel {
+        let dto = CreateWeeklyPlanDTO(taskIds: taskIds)
         do {
-            let dto = CreateWeeklyPlanDTO(taskIds: taskIds)
             let response: WeeklyCycleDTO = try await apiClient.request(
                 .createWeeklyPlan(playbookId: playbookId, dto: dto)
             )
             return try await upsertSingleCycle(response)
+        } catch let error as APIError where error.isOffline {
+            if let syncEngine {
+                let tempModel = try await insertOptimisticCycle(playbookId: playbookId, taskCount: taskIds.count)
+                await syncEngine.enqueue(
+                    path: "/v1/playbooks/\(playbookId)/weekly/plan",
+                    method: .post,
+                    body: dto,
+                    entityType: "weeklyCycle",
+                    entityId: tempModel.id
+                )
+                return tempModel
+            }
+            throw mapError(error)
         } catch let error as APIError {
             throw mapError(error)
         } catch let error as WeeklyPlanError {
@@ -145,6 +161,20 @@ final class WeeklyPlanService: WeeklyPlanServiceProtocol, Sendable {
     @MainActor
     private func upsertSingleCycle(_ dto: WeeklyCycleDTO) throws -> WeeklyCycleModel {
         try upsertCycles([dto]).first!
+    }
+
+    /// Inserts an optimistic weekly cycle with a temp ID for offline creates.
+    @MainActor
+    private func insertOptimisticCycle(playbookId: String, taskCount: Int) throws -> WeeklyCycleModel {
+        let context = modelContainer.mainContext
+        let model = WeeklyCycleModel(
+            playbookId: playbookId,
+            weekStartDate: .now,
+            totalCount: taskCount
+        )
+        context.insert(model)
+        try context.save()
+        return model
     }
 
     /// Returns cached weekly cycles from SwiftData (offline fallback).

--- a/idea-pilot/idea-pilot/Navigation/RootView.swift
+++ b/idea-pilot/idea-pilot/Navigation/RootView.swift
@@ -23,6 +23,7 @@ struct RootView: View {
     let taskService: any TaskServiceProtocol
     let sectionService: any SectionServiceProtocol
     let weeklyPlanService: any WeeklyPlanServiceProtocol
+    let syncEngine: SyncEngine?
 
     @State private var isAuthenticated = false
     @State private var isCheckingAuth = true
@@ -89,6 +90,7 @@ struct RootView: View {
     }
 
     private func signOut() {
+        syncEngine?.stop()
         guard let vm = authViewModel else {
             // Create a fresh ViewModel for the auth screen.
             let newVM = AuthViewModel(authService: authService)

--- a/idea-pilot/idea-pilotTests/SyncEngineTests.swift
+++ b/idea-pilot/idea-pilotTests/SyncEngineTests.swift
@@ -1,0 +1,650 @@
+//
+//  SyncEngineTests.swift
+//  idea-pilotTests
+//
+//  Unit tests for SyncEngine, MutationQueue, and related infrastructure.
+//
+
+import Foundation
+import SwiftData
+import Testing
+@testable import idea_pilot
+
+// MARK: - Mock URL Protocol
+
+/// A `URLProtocol` subclass for SyncEngine tests, independent of other mocks.
+final class SyncEngineMockURLProtocol: URLProtocol, @unchecked Sendable {
+
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> (Data, HTTPURLResponse))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = SyncEngineMockURLProtocol.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+
+        do {
+            let (data, response) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Test Helpers
+
+private let testBaseURL = URL(string: "https://api.test.ideapilot.app")!
+
+private func makeURLSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [SyncEngineMockURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+private nonisolated func makeResponse(statusCode: Int) -> HTTPURLResponse {
+    HTTPURLResponse(
+        url: testBaseURL,
+        statusCode: statusCode,
+        httpVersion: nil,
+        headerFields: nil
+    )!
+}
+
+private func makeInMemoryModelContainer() throws -> ModelContainer {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    return try ModelContainer(
+        for: PlaybookModel.self, TaskModel.self, SectionModel.self, WeeklyCycleModel.self, MutationEntry.self,
+        configurations: config
+    )
+}
+
+private func makeAPIClient(session: URLSession? = nil) -> APIClient {
+    let urlSession = session ?? makeURLSession()
+    return APIClient(baseURL: testBaseURL, session: urlSession)
+}
+
+private func makeSyncEngine(
+    session: URLSession? = nil
+) throws -> (SyncEngine, ModelContainer) {
+    let urlSession = session ?? makeURLSession()
+    let apiClient = APIClient(baseURL: testBaseURL, session: urlSession)
+    let container = try makeInMemoryModelContainer()
+    let engine = SyncEngine(apiClient: apiClient, modelContainer: container)
+    return (engine, container)
+}
+
+// MARK: - Mock JSON Fixtures
+
+private let createdTaskJSON = #"""
+{
+    "id": "server-task-1",
+    "playbook_id": "pb-1",
+    "title": "Created Task",
+    "detail": null,
+    "lane": "NOW",
+    "estimated_minutes": 60,
+    "status": "OPEN",
+    "order_index": 0,
+    "completed_at": null,
+    "created_at": "2025-01-01T00:00:00Z",
+    "updated_at": "2025-01-01T00:00:00Z"
+}
+"""#
+
+// MARK: - MutationQueue Tests
+
+@Suite("MutationQueue", .serialized)
+@MainActor
+struct MutationQueueTests {
+
+    @Test("enqueue creates a MutationEntry in SwiftData")
+    func enqueueCreatesEntry() throws {
+        let container = try makeInMemoryModelContainer()
+        let queue = MutationQueue(modelContainer: container)
+
+        try queue.enqueue(
+            path: "/v1/tasks",
+            method: .post,
+            bodyData: Data("{}".utf8),
+            entityType: "task",
+            entityId: "temp-1"
+        )
+
+        #expect(queue.pendingCount == 1)
+
+        let entry = try queue.peek()
+        #expect(entry != nil)
+        #expect(entry?.endpointPath == "/v1/tasks")
+        #expect(entry?.httpMethodRawValue == "POST")
+        #expect(entry?.entityType == "task")
+        #expect(entry?.entityId == "temp-1")
+        #expect(entry?.retryCount == 0)
+        #expect(entry?.status == .pending)
+    }
+
+    @Test("peek returns oldest pending entry (FIFO)")
+    func peekReturnsFIFO() throws {
+        let container = try makeInMemoryModelContainer()
+        let queue = MutationQueue(modelContainer: container)
+
+        // Enqueue two entries with different timestamps.
+        let context = container.mainContext
+        let older = MutationEntry(
+            endpointPath: "/v1/tasks/1",
+            httpMethod: .patch,
+            entityType: "task",
+            entityId: "1",
+            createdAt: Date(timeIntervalSince1970: 1000)
+        )
+        let newer = MutationEntry(
+            endpointPath: "/v1/tasks/2",
+            httpMethod: .patch,
+            entityType: "task",
+            entityId: "2",
+            createdAt: Date(timeIntervalSince1970: 2000)
+        )
+        context.insert(newer)
+        context.insert(older)
+        try context.save()
+
+        let first = try queue.peek()
+        #expect(first?.entityId == "1")
+    }
+
+    @Test("remove deletes entry from SwiftData")
+    func removeDeletesEntry() throws {
+        let container = try makeInMemoryModelContainer()
+        let queue = MutationQueue(modelContainer: container)
+
+        try queue.enqueue(
+            path: "/v1/tasks",
+            method: .post,
+            bodyData: nil,
+            entityType: "task",
+            entityId: nil
+        )
+
+        let entry = try queue.peek()
+        #expect(entry != nil)
+
+        try queue.remove(entry!)
+
+        let afterRemove = try queue.peek()
+        #expect(afterRemove == nil)
+        #expect(queue.pendingCount == 0)
+    }
+
+    @Test("markFailed increments retryCount and resets to pending")
+    func markFailedIncrementsRetry() throws {
+        let container = try makeInMemoryModelContainer()
+        let queue = MutationQueue(modelContainer: container)
+
+        try queue.enqueue(
+            path: "/v1/tasks",
+            method: .post,
+            bodyData: nil,
+            entityType: "task",
+            entityId: nil
+        )
+
+        let entry = try queue.peek()!
+        try queue.markInFlight(entry)
+        try queue.markFailed(entry)
+
+        #expect(entry.retryCount == 1)
+        #expect(entry.status == .pending)
+        #expect(entry.lastAttemptAt != nil)
+    }
+
+    @Test("markFailed removes entry after maxRetries exceeded")
+    func markFailedRemovesAfterMaxRetries() throws {
+        let container = try makeInMemoryModelContainer()
+        let queue = MutationQueue(modelContainer: container)
+
+        let context = container.mainContext
+        let entry = MutationEntry(
+            endpointPath: "/v1/tasks",
+            httpMethod: .post,
+            entityType: "task",
+            retryCount: 4,
+            maxRetries: 5
+        )
+        context.insert(entry)
+        try context.save()
+
+        // This is the 5th failure (retryCount becomes 5 == maxRetries), entry should be removed.
+        try queue.markFailed(entry)
+
+        let remaining = try queue.peek()
+        #expect(remaining == nil)
+    }
+
+    @Test("resetInFlightToPending recovers stale entries")
+    func resetInFlightRecovery() throws {
+        let container = try makeInMemoryModelContainer()
+        let queue = MutationQueue(modelContainer: container)
+
+        let context = container.mainContext
+        let entry = MutationEntry(
+            endpointPath: "/v1/tasks",
+            httpMethod: .post,
+            entityType: "task",
+            status: .inFlight
+        )
+        context.insert(entry)
+        try context.save()
+
+        // Before recovery, peek returns nil (inFlight != pending).
+        let beforeRecovery = try queue.peek()
+        #expect(beforeRecovery == nil)
+
+        try queue.resetInFlightToPending()
+
+        let afterRecovery = try queue.peek()
+        #expect(afterRecovery != nil)
+        #expect(afterRecovery?.status == .pending)
+    }
+
+    @Test("purge removes all entries")
+    func purgeRemovesAll() throws {
+        let container = try makeInMemoryModelContainer()
+        let queue = MutationQueue(modelContainer: container)
+
+        try queue.enqueue(path: "/v1/tasks", method: .post, bodyData: nil, entityType: "task", entityId: nil)
+        try queue.enqueue(path: "/v1/tasks", method: .post, bodyData: nil, entityType: "task", entityId: nil)
+
+        #expect(queue.pendingCount == 2)
+
+        try queue.purge()
+
+        #expect(queue.pendingCount == 0)
+    }
+}
+
+// MARK: - SyncEngine Tests
+
+@Suite("SyncEngine", .serialized)
+@MainActor
+struct SyncEngineTests {
+
+    // MARK: - Drain
+
+    @Test("drain sends queued mutation and removes on success")
+    func drainSuccessRemoves() async throws {
+        SyncEngineMockURLProtocol.handler = { _ in
+            (Data(createdTaskJSON.utf8), makeResponse(statusCode: 201))
+        }
+
+        let (engine, _) = try makeSyncEngine()
+
+        // Enqueue a mutation.
+        engine.enqueue(
+            path: "/v1/tasks",
+            method: .post,
+            body: CreateTaskDTO(playbookId: "pb-1", title: "Test", detail: nil, lane: "NOW", estimatedMinutes: 60),
+            entityType: "task",
+            entityId: "temp-1"
+        )
+
+        #expect(engine.mutationQueue.pendingCount == 1)
+
+        // Drain manually.
+        await engine.onPullToRefresh()
+
+        #expect(engine.mutationQueue.pendingCount == 0)
+
+        SyncEngineMockURLProtocol.handler = nil
+    }
+
+    @Test("drain retries on 500 server error")
+    func drainRetriesOnServerError() async throws {
+        SyncEngineMockURLProtocol.handler = { _ in
+            (Data(#"{"message":"Internal error"}"#.utf8), makeResponse(statusCode: 500))
+        }
+
+        let (engine, _) = try makeSyncEngine()
+
+        engine.enqueue(
+            path: "/v1/tasks",
+            method: .post,
+            body: CreateTaskDTO(playbookId: "pb-1", title: "Test", detail: nil, lane: "NOW", estimatedMinutes: 60),
+            entityType: "task"
+        )
+
+        await engine.onPullToRefresh()
+
+        // Entry should still be in queue with incremented retryCount.
+        let entry = try engine.mutationQueue.peek()
+        #expect(entry != nil)
+        #expect(entry?.retryCount == 1)
+        #expect(entry?.status == .pending)
+
+        SyncEngineMockURLProtocol.handler = nil
+    }
+
+    @Test("drain discards mutation on 400 bad request")
+    func drainDiscardsOn400() async throws {
+        SyncEngineMockURLProtocol.handler = { _ in
+            (Data(#"{"message":"Bad request"}"#.utf8), makeResponse(statusCode: 400))
+        }
+
+        let (engine, _) = try makeSyncEngine()
+
+        engine.enqueue(
+            path: "/v1/tasks",
+            method: .post,
+            body: CreateTaskDTO(playbookId: "pb-1", title: "Test", detail: nil, lane: "NOW", estimatedMinutes: 60),
+            entityType: "task"
+        )
+
+        await engine.onPullToRefresh()
+
+        // Non-retryable error — entry should be discarded.
+        #expect(engine.mutationQueue.pendingCount == 0)
+
+        SyncEngineMockURLProtocol.handler = nil
+    }
+
+    @Test("drain discards mutation on 404 not found")
+    func drainDiscardsOn404() async throws {
+        SyncEngineMockURLProtocol.handler = { _ in
+            (Data(), makeResponse(statusCode: 404))
+        }
+
+        let (engine, _) = try makeSyncEngine()
+
+        engine.enqueue(
+            path: "/v1/tasks/nonexistent",
+            method: .patch,
+            body: UpdateTaskDTO(title: "Update", detail: nil, lane: nil, estimatedMinutes: nil, status: nil, orderIndex: nil),
+            entityType: "task",
+            entityId: "nonexistent"
+        )
+
+        await engine.onPullToRefresh()
+
+        #expect(engine.mutationQueue.pendingCount == 0)
+
+        SyncEngineMockURLProtocol.handler = nil
+    }
+
+    @Test("drain processes multiple mutations in FIFO order")
+    func drainFIFOOrder() async throws {
+        nonisolated(unsafe) var capturedPaths: [String] = []
+
+        SyncEngineMockURLProtocol.handler = { request in
+            capturedPaths.append(request.url?.path ?? "")
+            return (Data(createdTaskJSON.utf8), makeResponse(statusCode: 200))
+        }
+
+        let (engine, container) = try makeSyncEngine()
+
+        // Insert entries with explicit timestamps to control order.
+        let context = container.mainContext
+        let first = MutationEntry(
+            endpointPath: "/v1/tasks/first",
+            httpMethod: .patch,
+            entityType: "task",
+            createdAt: Date(timeIntervalSince1970: 1000)
+        )
+        let second = MutationEntry(
+            endpointPath: "/v1/tasks/second",
+            httpMethod: .patch,
+            entityType: "task",
+            createdAt: Date(timeIntervalSince1970: 2000)
+        )
+        context.insert(first)
+        context.insert(second)
+        try context.save()
+
+        await engine.onPullToRefresh()
+
+        #expect(capturedPaths.count == 2)
+        #expect(capturedPaths[0].contains("first"))
+        #expect(capturedPaths[1].contains("second"))
+
+        SyncEngineMockURLProtocol.handler = nil
+    }
+
+    @Test("drain stops when network becomes unavailable")
+    func drainStopsOffline() async throws {
+        nonisolated(unsafe) var requestCount = 0
+
+        SyncEngineMockURLProtocol.handler = { _ in
+            requestCount += 1
+            return (Data(createdTaskJSON.utf8), makeResponse(statusCode: 200))
+        }
+
+        let (engine, _) = try makeSyncEngine()
+
+        // Mark as offline — drain should not execute.
+        engine.networkMonitor.isConnected = false
+
+        engine.enqueue(
+            path: "/v1/tasks",
+            method: .post,
+            body: CreateTaskDTO(playbookId: "pb-1", title: "Test", detail: nil, lane: "NOW", estimatedMinutes: 60),
+            entityType: "task"
+        )
+
+        await engine.onPullToRefresh()
+
+        #expect(requestCount == 0)
+        #expect(engine.mutationQueue.pendingCount == 1)
+
+        SyncEngineMockURLProtocol.handler = nil
+    }
+
+    // MARK: - Create Reconciliation
+
+    @Test("drain reconciles POST create by replacing temp model with server model")
+    func drainReconcilesPOSTCreate() async throws {
+        SyncEngineMockURLProtocol.handler = { _ in
+            (Data(createdTaskJSON.utf8), makeResponse(statusCode: 201))
+        }
+
+        let (engine, container) = try makeSyncEngine()
+
+        // Insert a temp task model (simulating optimistic insert).
+        let context = container.mainContext
+        let tempTask = TaskModel(id: "temp-task-1", playbookId: "pb-1", title: "Created Task", lane: .now, estimatedMinutes: 60)
+        context.insert(tempTask)
+        try context.save()
+
+        // Enqueue a create mutation with the temp ID.
+        engine.enqueue(
+            path: "/v1/tasks",
+            method: .post,
+            body: CreateTaskDTO(playbookId: "pb-1", title: "Created Task", detail: nil, lane: "NOW", estimatedMinutes: 60),
+            entityType: "task",
+            entityId: "temp-task-1"
+        )
+
+        await engine.onPullToRefresh()
+
+        // Temp model should be gone, server model should exist.
+        let tempPredicate = #Predicate<TaskModel> { $0.id == "temp-task-1" }
+        var tempDescriptor = FetchDescriptor(predicate: tempPredicate)
+        tempDescriptor.fetchLimit = 1
+        let tempResult = try context.fetch(tempDescriptor)
+        #expect(tempResult.isEmpty)
+
+        let serverPredicate = #Predicate<TaskModel> { $0.id == "server-task-1" }
+        var serverDescriptor = FetchDescriptor(predicate: serverPredicate)
+        serverDescriptor.fetchLimit = 1
+        let serverResult = try context.fetch(serverDescriptor)
+        #expect(serverResult.count == 1)
+        #expect(serverResult.first?.title == "Created Task")
+
+        SyncEngineMockURLProtocol.handler = nil
+    }
+
+    // MARK: - Status
+
+    @Test("status is .synced when queue is empty and connected")
+    func statusSyncedWhenEmpty() async throws {
+        let (engine, _) = try makeSyncEngine()
+
+        engine.networkMonitor.isConnected = true
+
+        // Force status update by triggering a no-op drain.
+        SyncEngineMockURLProtocol.handler = { _ in
+            (Data(), makeResponse(statusCode: 200))
+        }
+        await engine.onPullToRefresh()
+
+        #expect(engine.status.value == .synced)
+
+        SyncEngineMockURLProtocol.handler = nil
+    }
+
+    @Test("status is .pending(count) when mutations queued")
+    func statusPendingWithCount() async throws {
+        let (engine, _) = try makeSyncEngine()
+
+        engine.networkMonitor.isConnected = false
+
+        engine.enqueue(
+            path: "/v1/tasks",
+            method: .post,
+            body: CreateTaskDTO(playbookId: "pb-1", title: "Test", detail: nil, lane: "NOW", estimatedMinutes: 60),
+            entityType: "task"
+        )
+
+        // When offline with pending mutations, onAppForeground updates status.
+        engine.onAppForeground()
+        // Give the Task a tick to run.
+        try await Task.sleep(for: .milliseconds(50))
+
+        // Status should reflect offline state.
+        #expect(engine.status.value == .offline)
+
+        // Now go online.
+        engine.networkMonitor.isConnected = true
+
+        engine.enqueue(
+            path: "/v1/tasks",
+            method: .post,
+            body: CreateTaskDTO(playbookId: "pb-1", title: "Test 2", detail: nil, lane: "NOW", estimatedMinutes: 60),
+            entityType: "task"
+        )
+
+        // After enqueue with connected, status should be pending.
+        #expect(engine.mutationQueue.pendingCount == 2)
+    }
+
+    @Test("status is .offline when disconnected")
+    func statusOfflineWhenDisconnected() async throws {
+        let (engine, _) = try makeSyncEngine()
+
+        engine.networkMonitor.isConnected = false
+
+        engine.enqueue(
+            path: "/v1/tasks",
+            method: .post,
+            body: CreateTaskDTO(playbookId: "pb-1", title: "Test", detail: nil, lane: "NOW", estimatedMinutes: 60),
+            entityType: "task"
+        )
+
+        // Trigger status update.
+        await engine.onPullToRefresh()
+
+        #expect(engine.status.value == .offline)
+    }
+
+    // MARK: - Backoff
+
+    @Test("drain respects exponential backoff timing")
+    func drainRespectsBackoff() async throws {
+        nonisolated(unsafe) var requestCount = 0
+
+        SyncEngineMockURLProtocol.handler = { _ in
+            requestCount += 1
+            return (Data(#"{"message":"Error"}"#.utf8), makeResponse(statusCode: 500))
+        }
+
+        let (engine, _) = try makeSyncEngine()
+
+        engine.enqueue(
+            path: "/v1/tasks",
+            method: .post,
+            body: CreateTaskDTO(playbookId: "pb-1", title: "Test", detail: nil, lane: "NOW", estimatedMinutes: 60),
+            entityType: "task"
+        )
+
+        // First drain — should attempt and fail.
+        await engine.onPullToRefresh()
+        #expect(requestCount == 1)
+
+        // Second drain immediately — should skip due to backoff.
+        await engine.onPullToRefresh()
+        #expect(requestCount == 1) // No new request because backoff hasn't elapsed.
+
+        SyncEngineMockURLProtocol.handler = nil
+    }
+
+    // MARK: - Enqueue
+
+    @Test("enqueue serializes body with snake_case encoding")
+    func enqueueSerializesBody() throws {
+        let (engine, _) = try makeSyncEngine()
+
+        engine.enqueue(
+            path: "/v1/tasks",
+            method: .post,
+            body: CreateTaskDTO(playbookId: "pb-1", title: "Test", detail: nil, lane: "NOW", estimatedMinutes: 60),
+            entityType: "task",
+            entityId: "temp-1"
+        )
+
+        let entry = try engine.mutationQueue.peek()
+        #expect(entry != nil)
+        #expect(entry?.bodyData != nil)
+
+        // Verify the body is snake_case encoded.
+        let bodyString = String(data: entry!.bodyData!, encoding: .utf8) ?? ""
+        #expect(bodyString.contains("playbook_id"))
+        #expect(bodyString.contains("estimated_minutes"))
+    }
+
+    @Test("enqueue with nil body stores nil bodyData")
+    func enqueueNilBody() throws {
+        let (engine, _) = try makeSyncEngine()
+
+        engine.enqueue(
+            path: "/v1/tasks/1/complete",
+            method: .post,
+            body: nil as CreateTaskDTO?,
+            entityType: "task",
+            entityId: "1"
+        )
+
+        let entry = try engine.mutationQueue.peek()
+        #expect(entry != nil)
+        #expect(entry?.bodyData == nil)
+    }
+}
+
+// MARK: - SyncStatus Tests
+
+@Suite("SyncStatus")
+struct SyncStatusTests {
+
+    @Test("SyncStatusValue equality works correctly")
+    func syncStatusEquality() {
+        #expect(SyncStatusValue.synced == SyncStatusValue.synced)
+        #expect(SyncStatusValue.offline == SyncStatusValue.offline)
+        #expect(SyncStatusValue.pending(3) == SyncStatusValue.pending(3))
+        #expect(SyncStatusValue.pending(3) != SyncStatusValue.pending(5))
+        #expect(SyncStatusValue.syncing != SyncStatusValue.synced)
+        #expect(SyncStatusValue.error("test") == SyncStatusValue.error("test"))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds persistent mutation queue (`MutationEntry` SwiftData model + `MutationQueue` FIFO queue) so offline writes survive app restarts
- Introduces `SyncEngine` orchestrator that drains the queue on connectivity restore, app foreground, pull-to-refresh, and post-mutation (debounced 2s)
- Adds `NetworkMonitor` (NWPathMonitor wrapper) and `SyncStatus` (observable enum for UI indicators)
- Extends `APIClient` with `replayMutation()` for pre-encoded mutation replay with full auth handling
- Integrates all 4 services (Task, Playbook, Section, WeeklyPlan) to enqueue offline writes with optimistic local updates
- Includes 21 unit tests covering queue operations, drain logic, retry/backoff, status transitions, and POST create reconciliation

## Test plan
- [x] Build succeeds with zero errors
- [x] All 260 tests pass (21 new SyncEngine tests + 239 existing)
- [ ] Manual: toggle airplane mode, create/update tasks, verify mutations queue and replay on reconnect
- [ ] Manual: verify SyncStatus reflects correct state (synced/pending/offline)
- [ ] Manual: verify sign-out purges mutation queue

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)