### PR TITLE
feat: Settings view — account, sync status, sign out (#30)

### DIFF
--- a/idea-pilot/idea-pilot/Core/Sync/SyncEngine.swift
+++ b/idea-pilot/idea-pilot/Core/Sync/SyncEngine.swift
@@ -54,6 +54,9 @@ final class SyncEngine: @unchecked Sendable {
 
     // MARK: - Internal State
 
+    /// Timestamp of the last successful sync drain.
+    var lastSyncDate: Date?
+
     private var isDraining = false
     private var debounceTask: Task<Void, Never>?
 
@@ -266,6 +269,9 @@ final class SyncEngine: @unchecked Sendable {
 
         isDraining = false
         updateStatus()
+        if case .synced = status.value {
+            lastSyncDate = .now
+        }
     }
 
     // MARK: - Create Reconciliation

--- a/idea-pilot/idea-pilot/Features/Playbooks/Views/PlaybookListView.swift
+++ b/idea-pilot/idea-pilot/Features/Playbooks/Views/PlaybookListView.swift
@@ -22,6 +22,12 @@ struct PlaybookListView: View {
     let taskService: any TaskServiceProtocol
     let sectionService: any SectionServiceProtocol
     let weeklyPlanService: any WeeklyPlanServiceProtocol
+    let tokenManager: TokenManager
+    let authService: any AuthServiceProtocol
+    let syncEngine: SyncEngine?
+    let onSignOut: () -> Void
+
+    @State private var showSettings = false
 
     var body: some View {
         ScrollView {
@@ -50,7 +56,7 @@ struct PlaybookListView: View {
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
-                    // Settings placeholder — future issue
+                    showSettings = true
                 } label: {
                     Image(systemName: "gearshape")
                         .foregroundStyle(Color.theme.mutedForeground)
@@ -60,6 +66,16 @@ struct PlaybookListView: View {
         }
         .sheet(isPresented: $vm.showCreateSheet) {
             CreatePlaybookSheet(vm: vm)
+        }
+        .fullScreenCover(isPresented: $showSettings) {
+            SettingsView(
+                vm: SettingsViewModel(
+                    tokenManager: tokenManager,
+                    authService: authService,
+                    syncEngine: syncEngine,
+                    onSignOut: onSignOut
+                )
+            )
         }
     }
 
@@ -400,6 +416,8 @@ private struct CreatePlaybookSheet: View {
 
 // MARK: - Preview
 
+private let previewTokenManager = TokenManager(baseURL: URL(string: "https://api.test.ideapilot.app")!)
+
 #Preview("Populated") {
     NavigationStack {
         PlaybookListView(
@@ -415,7 +433,11 @@ private struct CreatePlaybookSheet: View {
             }(),
             taskService: PlaybookListPreviewTaskService(),
             sectionService: PlaybookListPreviewSectionService(),
-            weeklyPlanService: PlaybookListPreviewWeeklyPlanService()
+            weeklyPlanService: PlaybookListPreviewWeeklyPlanService(),
+            tokenManager: previewTokenManager,
+            authService: PlaybookListPreviewAuthService(),
+            syncEngine: nil,
+            onSignOut: {}
         )
     }
 }
@@ -426,7 +448,11 @@ private struct CreatePlaybookSheet: View {
             vm: PlaybookListViewModel(playbookService: PlaybookListPreviewPlaybookService()),
             taskService: PlaybookListPreviewTaskService(),
             sectionService: PlaybookListPreviewSectionService(),
-            weeklyPlanService: PlaybookListPreviewWeeklyPlanService()
+            weeklyPlanService: PlaybookListPreviewWeeklyPlanService(),
+            tokenManager: previewTokenManager,
+            authService: PlaybookListPreviewAuthService(),
+            syncEngine: nil,
+            onSignOut: {}
         )
     }
 }
@@ -441,7 +467,11 @@ private struct CreatePlaybookSheet: View {
             }(),
             taskService: PlaybookListPreviewTaskService(),
             sectionService: PlaybookListPreviewSectionService(),
-            weeklyPlanService: PlaybookListPreviewWeeklyPlanService()
+            weeklyPlanService: PlaybookListPreviewWeeklyPlanService(),
+            tokenManager: previewTokenManager,
+            authService: PlaybookListPreviewAuthService(),
+            syncEngine: nil,
+            onSignOut: {}
         )
     }
 }
@@ -472,6 +502,20 @@ private struct PlaybookListPreviewWeeklyPlanService: WeeklyPlanServiceProtocol {
         WeeklyCycleModel(playbookId: playbookId, weekStartDate: .now, totalCount: taskIds.count)
     }
     func fetchWeeklyCycles(playbookId: String) async throws -> [WeeklyCycleModel] { [] }
+}
+
+/// A no-op auth service for SwiftUI previews.
+private struct PlaybookListPreviewAuthService: AuthServiceProtocol {
+    func login(email: String, password: String) async throws -> UserSession {
+        UserSession(userId: "1", email: email, accessToken: "t", refreshToken: "r")
+    }
+    func register(email: String, password: String) async throws -> UserSession {
+        UserSession(userId: "1", email: email, accessToken: "t", refreshToken: "r")
+    }
+    func auth0Login(idToken: String) async throws -> UserSession {
+        UserSession(userId: "1", email: "test@test.com", accessToken: "t", refreshToken: "r")
+    }
+    func logout() async throws {}
 }
 
 /// A no-op task service for SwiftUI previews.

--- a/idea-pilot/idea-pilot/Features/Settings/ViewModels/SettingsViewModel.swift
+++ b/idea-pilot/idea-pilot/Features/Settings/ViewModels/SettingsViewModel.swift
@@ -1,0 +1,124 @@
+//
+//  SettingsViewModel.swift
+//  idea-pilot
+//
+//  ViewModel for the Settings screen.
+//  Manages account info, sync status display, and sign-out flow.
+//
+
+import Foundation
+
+/// ViewModel driving the Settings screen.
+///
+/// Loads the user's email from `TokenManager`, exposes sync status
+/// from `SyncEngine`, and manages the sign-out flow with a confirmation
+/// dialog when unsynced mutations are pending.
+@Observable
+final class SettingsViewModel {
+
+    // MARK: - State
+
+    /// The authenticated user's email address.
+    var email: String?
+
+    /// Whether a manual sync is in progress.
+    var isSyncing = false
+
+    /// Triggers the sign-out confirmation dialog.
+    var showSignOutConfirmation = false
+
+    // MARK: - Dependencies
+
+    private let tokenManager: TokenManager
+    private let authService: any AuthServiceProtocol
+    private let syncEngine: SyncEngine?
+    private let onSignOut: () -> Void
+
+    // MARK: - Init
+
+    /// Creates a SettingsViewModel.
+    ///
+    /// - Parameters:
+    ///   - tokenManager: Provides user email and auth state.
+    ///   - authService: Handles logout API call.
+    ///   - syncEngine: Provides sync status and manual sync trigger.
+    ///   - onSignOut: Callback fired after sign-out completes.
+    init(
+        tokenManager: TokenManager,
+        authService: any AuthServiceProtocol,
+        syncEngine: SyncEngine?,
+        onSignOut: @escaping () -> Void
+    ) {
+        self.tokenManager = tokenManager
+        self.authService = authService
+        self.syncEngine = syncEngine
+        self.onSignOut = onSignOut
+    }
+
+    // MARK: - Computed
+
+    /// The current sync status value from the engine.
+    var syncStatusValue: SyncStatusValue {
+        syncEngine?.status.value ?? .synced
+    }
+
+    /// Number of mutations waiting to be synced.
+    var pendingCount: Int {
+        syncEngine?.mutationQueue.pendingCount ?? 0
+    }
+
+    /// Whether unsynced mutations exist in the queue.
+    var hasPendingMutations: Bool {
+        pendingCount > 0
+    }
+
+    /// Whether the device is currently connected to the network.
+    var isConnected: Bool {
+        syncEngine?.networkMonitor.isConnected ?? true
+    }
+
+    /// Formatted last sync timestamp, or `nil` if never synced.
+    var lastSyncText: String? {
+        guard let date = syncEngine?.lastSyncDate else { return nil }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        return formatter.localizedString(for: date, relativeTo: .now)
+    }
+
+    /// The app version string for display.
+    var appVersion: String {
+        AppConfiguration.versionDisplay
+    }
+
+    // MARK: - Actions
+
+    /// Loads the user's email from the TokenManager actor.
+    func loadEmail() async {
+        email = await tokenManager.email
+    }
+
+    /// Triggers a manual sync. Awaitable for UI spinner binding.
+    func syncNow() async {
+        guard !isSyncing else { return }
+        isSyncing = true
+        await syncEngine?.onPullToRefresh()
+        isSyncing = false
+    }
+
+    /// Initiates sign-out. Shows confirmation if unsynced mutations exist.
+    func confirmSignOut() {
+        if hasPendingMutations {
+            showSignOutConfirmation = true
+        } else {
+            performSignOut()
+        }
+    }
+
+    /// Executes the sign-out: logs out via API, then fires the callback.
+    func performSignOut() {
+        Task {
+            try? await authService.logout()
+        }
+        onSignOut()
+    }
+}

--- a/idea-pilot/idea-pilot/Features/Settings/Views/SettingsView.swift
+++ b/idea-pilot/idea-pilot/Features/Settings/Views/SettingsView.swift
@@ -1,0 +1,329 @@
+//
+//  SettingsView.swift
+//  idea-pilot
+//
+//  Full-screen settings modal with account, sync status, and sign-out.
+//  Accessible from the gear icon in PlaybookListView.
+//
+
+import SwiftUI
+
+/// The Settings screen presented as a full-screen modal.
+///
+/// Sections:
+/// 1. **Account** — user email
+/// 2. **Sync** — status indicator, last sync time, pending count, Sync Now button
+/// 3. **About** — app version, links placeholder
+/// 4. **Sign Out** — destructive button with confirmation when mutations pending
+struct SettingsView: View {
+
+    @Bindable var vm: SettingsViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 24) {
+                    accountSection
+                    syncSection
+                    aboutSection
+                    signOutButton
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
+                .padding(.bottom, 32)
+            }
+            .themeBackground()
+            .navigationTitle("Settings")
+            .navigationBarTitleDisplayMode(.large)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                    .fontWeight(.semibold)
+                    .foregroundStyle(Color.theme.primary)
+                }
+            }
+            .task { await vm.loadEmail() }
+            .confirmationDialog(
+                "Sign Out?",
+                isPresented: $vm.showSignOutConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button("Sign Out", role: .destructive) {
+                    vm.performSignOut()
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("You have unsynced changes that will be lost.")
+            }
+        }
+    }
+
+    // MARK: - Account Section
+
+    private var accountSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionHeader("ACCOUNT")
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Image(systemName: "person.circle.fill")
+                        .font(.system(size: 20))
+                        .foregroundStyle(Color.theme.mutedForeground)
+
+                    Text(vm.email ?? "Loading…")
+                        .font(.theme.body)
+                        .foregroundStyle(Color.theme.foreground)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(16)
+            .cardStyle()
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Account, \(vm.email ?? "loading")")
+    }
+
+    // MARK: - Sync Section
+
+    private var syncSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionHeader("SYNC")
+
+            VStack(spacing: 0) {
+                // Status row
+                settingsRow {
+                    HStack(spacing: 8) {
+                        Text("Status")
+                            .font(.theme.body)
+                            .foregroundStyle(Color.theme.foreground)
+
+                        Spacer()
+
+                        syncStatusIndicator
+                    }
+                }
+
+                Divider()
+                    .background(Color.theme.border)
+
+                // Last sync row
+                settingsRow {
+                    HStack {
+                        Text("Last Sync")
+                            .font(.theme.body)
+                            .foregroundStyle(Color.theme.foreground)
+
+                        Spacer()
+
+                        Text(vm.lastSyncText ?? "Never")
+                            .font(.theme.subheadline)
+                            .foregroundStyle(Color.theme.mutedForeground)
+                    }
+                }
+
+                if vm.pendingCount > 0 {
+                    Divider()
+                        .background(Color.theme.border)
+
+                    // Pending mutations row
+                    settingsRow {
+                        HStack {
+                            Text("Pending Changes")
+                                .font(.theme.body)
+                                .foregroundStyle(Color.theme.foreground)
+
+                            Spacer()
+
+                            Text("\(vm.pendingCount)")
+                                .font(.theme.subheadline)
+                                .foregroundStyle(Color.yellow)
+                        }
+                    }
+                }
+
+                Divider()
+                    .background(Color.theme.border)
+
+                // Sync Now button row
+                settingsRow {
+                    Button {
+                        Task { await vm.syncNow() }
+                    } label: {
+                        HStack {
+                            Text("Sync Now")
+                                .font(.theme.body)
+                                .foregroundStyle(
+                                    vm.isConnected && !vm.isSyncing
+                                        ? Color.theme.primary
+                                        : Color.theme.mutedForeground
+                                )
+
+                            Spacer()
+
+                            if vm.isSyncing {
+                                ProgressView()
+                                    .tint(Color.theme.primary)
+                            }
+                        }
+                    }
+                    .disabled(!vm.isConnected || vm.isSyncing)
+                    .accessibilityLabel("Sync now")
+                    .accessibilityHint(
+                        vm.isConnected
+                            ? "Triggers an immediate sync"
+                            : "Unavailable while offline"
+                    )
+                }
+            }
+            .cardStyle()
+        }
+    }
+
+    // MARK: - About Section
+
+    private var aboutSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionHeader("ABOUT")
+
+            VStack(spacing: 0) {
+                settingsRow {
+                    HStack {
+                        Text("Version")
+                            .font(.theme.body)
+                            .foregroundStyle(Color.theme.foreground)
+
+                        Spacer()
+
+                        Text(vm.appVersion)
+                            .font(.theme.subheadline)
+                            .foregroundStyle(Color.theme.mutedForeground)
+                    }
+                }
+
+                Divider()
+                    .background(Color.theme.border)
+
+                settingsRow {
+                    HStack {
+                        Text("Links")
+                            .font(.theme.body)
+                            .foregroundStyle(Color.theme.foreground)
+
+                        Spacer()
+
+                        Text("Coming soon")
+                            .font(.theme.subheadline)
+                            .foregroundStyle(Color.theme.mutedForeground)
+                    }
+                }
+            }
+            .cardStyle()
+        }
+    }
+
+    // MARK: - Sign Out Button
+
+    private var signOutButton: some View {
+        Button {
+            vm.confirmSignOut()
+        } label: {
+            Text("Sign Out")
+                .font(.theme.body)
+                .fontWeight(.semibold)
+                .foregroundStyle(Color.theme.destructive)
+                .frame(maxWidth: .infinity)
+                .frame(height: 50)
+                .background(Color.theme.destructive.opacity(0.1))
+                .clipShape(RoundedRectangle(cornerRadius: .theme.radiusMd))
+                .overlay(
+                    RoundedRectangle(cornerRadius: .theme.radiusMd)
+                        .stroke(Color.theme.destructive.opacity(0.3), lineWidth: 1)
+                )
+        }
+        .buttonStyle(.pressable)
+        .accessibilityLabel("Sign out")
+        .accessibilityHint(
+            vm.hasPendingMutations
+                ? "You have unsynced changes"
+                : "Signs you out of your account"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.theme.overline)
+            .foregroundStyle(Color.theme.mutedForeground)
+            .tracking(1.0)
+    }
+
+    private func settingsRow<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        content()
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+    }
+
+    @ViewBuilder
+    private var syncStatusIndicator: some View {
+        switch vm.syncStatusValue {
+        case .synced:
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(Color.green)
+                    .frame(width: 8, height: 8)
+                Text("Synced")
+                    .font(.theme.subheadline)
+                    .foregroundStyle(Color.theme.mutedForeground)
+            }
+            .accessibilityLabel("Synced")
+
+        case .syncing:
+            HStack(spacing: 6) {
+                ProgressView()
+                    .scaleEffect(0.7)
+                    .tint(Color.theme.primary)
+                Text("Syncing…")
+                    .font(.theme.subheadline)
+                    .foregroundStyle(Color.theme.primary)
+            }
+            .accessibilityLabel("Syncing")
+
+        case .pending(let count):
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(Color.yellow)
+                    .frame(width: 8, height: 8)
+                Text("\(count) pending")
+                    .font(.theme.subheadline)
+                    .foregroundStyle(Color.theme.mutedForeground)
+            }
+            .accessibilityLabel("\(count) changes pending")
+
+        case .error(let message):
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(Color.theme.destructive)
+                    .frame(width: 8, height: 8)
+                Text("Error")
+                    .font(.theme.subheadline)
+                    .foregroundStyle(Color.theme.destructive)
+            }
+            .accessibilityLabel("Sync error: \(message)")
+
+        case .offline:
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(Color.gray)
+                    .frame(width: 8, height: 8)
+                Text("Offline")
+                    .font(.theme.subheadline)
+                    .foregroundStyle(Color.theme.mutedForeground)
+            }
+            .accessibilityLabel("Offline")
+        }
+    }
+}

--- a/idea-pilot/idea-pilot/Navigation/MainTabView.swift
+++ b/idea-pilot/idea-pilot/Navigation/MainTabView.swift
@@ -60,17 +60,23 @@ struct MainTabView: View {
     let playbookService: any PlaybookServiceProtocol
     let sectionService: any SectionServiceProtocol
     let weeklyPlanService: any WeeklyPlanServiceProtocol
+    let tokenManager: TokenManager
+    let authService: any AuthServiceProtocol
+    let syncEngine: SyncEngine?
 
     @State private var selectedTab: AppTab = .now
     @State private var playbookListVM: PlaybookListViewModel
     @State private var showQuickAddSheet = false
 
-    init(playbookService: any PlaybookServiceProtocol, taskService: any TaskServiceProtocol, sectionService: any SectionServiceProtocol, weeklyPlanService: any WeeklyPlanServiceProtocol, onSignOut: @escaping () -> Void) {
+    init(playbookService: any PlaybookServiceProtocol, taskService: any TaskServiceProtocol, sectionService: any SectionServiceProtocol, weeklyPlanService: any WeeklyPlanServiceProtocol, tokenManager: TokenManager, authService: any AuthServiceProtocol, syncEngine: SyncEngine?, onSignOut: @escaping () -> Void) {
         self.onSignOut = onSignOut
         self.taskService = taskService
         self.playbookService = playbookService
         self.sectionService = sectionService
         self.weeklyPlanService = weeklyPlanService
+        self.tokenManager = tokenManager
+        self.authService = authService
+        self.syncEngine = syncEngine
         self._playbookListVM = State(initialValue: PlaybookListViewModel(playbookService: playbookService))
     }
 
@@ -107,7 +113,7 @@ struct MainTabView: View {
             .opacity(selectedTab == .now ? 1 : 0)
 
             NavigationStack {
-                PlaybookListView(vm: playbookListVM, taskService: taskService, sectionService: sectionService, weeklyPlanService: weeklyPlanService)
+                PlaybookListView(vm: playbookListVM, taskService: taskService, sectionService: sectionService, weeklyPlanService: weeklyPlanService, tokenManager: tokenManager, authService: authService, syncEngine: syncEngine, onSignOut: onSignOut)
             }
             .opacity(selectedTab == .playbooks ? 1 : 0)
         }
@@ -226,8 +232,25 @@ private struct NowPlaceholderView: View {
         taskService: MainTabPreviewTaskService(),
         sectionService: MainTabPreviewSectionService(),
         weeklyPlanService: MainTabPreviewWeeklyPlanService(),
+        tokenManager: TokenManager(baseURL: URL(string: "https://api.test.ideapilot.app")!),
+        authService: MainTabPreviewAuthService(),
+        syncEngine: nil,
         onSignOut: {}
     )
+}
+
+/// A no-op auth service for MainTabView previews.
+private struct MainTabPreviewAuthService: AuthServiceProtocol {
+    func login(email: String, password: String) async throws -> UserSession {
+        UserSession(userId: "1", email: email, accessToken: "t", refreshToken: "r")
+    }
+    func register(email: String, password: String) async throws -> UserSession {
+        UserSession(userId: "1", email: email, accessToken: "t", refreshToken: "r")
+    }
+    func auth0Login(idToken: String) async throws -> UserSession {
+        UserSession(userId: "1", email: "test@test.com", accessToken: "t", refreshToken: "r")
+    }
+    func logout() async throws {}
 }
 
 /// A no-op playbook service for MainTabView previews.

--- a/idea-pilot/idea-pilot/Navigation/RootView.swift
+++ b/idea-pilot/idea-pilot/Navigation/RootView.swift
@@ -34,7 +34,7 @@ struct RootView: View {
             if isCheckingAuth {
                 splashView
             } else if isAuthenticated {
-                MainTabView(playbookService: playbookService, taskService: taskService, sectionService: sectionService, weeklyPlanService: weeklyPlanService, onSignOut: signOut)
+                MainTabView(playbookService: playbookService, taskService: taskService, sectionService: sectionService, weeklyPlanService: weeklyPlanService, tokenManager: tokenManager, authService: authService, syncEngine: syncEngine, onSignOut: signOut)
             } else if let vm = authViewModel {
                 AuthView(vm: vm)
             }

--- a/idea-pilot/idea-pilotTests/SettingsViewModelTests.swift
+++ b/idea-pilot/idea-pilotTests/SettingsViewModelTests.swift
@@ -1,0 +1,299 @@
+//
+//  SettingsViewModelTests.swift
+//  idea-pilotTests
+//
+//  Unit tests for SettingsViewModel.
+//
+
+import Foundation
+import SwiftData
+import Testing
+@testable import idea_pilot
+
+// MARK: - Mock Auth Service
+
+private struct MockSettingsAuthService: AuthServiceProtocol {
+    func login(email: String, password: String) async throws -> UserSession {
+        UserSession(userId: "1", email: email, accessToken: "t", refreshToken: "r")
+    }
+    func register(email: String, password: String) async throws -> UserSession {
+        UserSession(userId: "1", email: email, accessToken: "t", refreshToken: "r")
+    }
+    func auth0Login(idToken: String) async throws -> UserSession {
+        UserSession(userId: "1", email: "test@test.com", accessToken: "t", refreshToken: "r")
+    }
+    func logout() async throws {}
+}
+
+// MARK: - Mock Keychain
+
+private final class MockKeychain: KeychainStorable, @unchecked Sendable {
+    private var store: [String: String] = [:]
+
+    func save(_ value: String, forKey key: String) throws {
+        store[key] = value
+    }
+    func load(forKey key: String) throws -> String? {
+        store[key]
+    }
+    func delete(forKey key: String) throws {
+        store.removeValue(forKey: key)
+    }
+}
+
+// MARK: - Test Helpers
+
+private let testBaseURL = URL(string: "https://api.test.ideapilot.app")!
+
+private func makeTokenManager(email: String? = "test@example.com") async throws -> TokenManager {
+    let keychain = MockKeychain()
+    let tm = TokenManager(keychain: keychain, baseURL: testBaseURL)
+    if let email {
+        try await tm.storeSession(UserSession(
+            userId: "user-1",
+            email: email,
+            accessToken: "access",
+            refreshToken: "refresh"
+        ))
+    }
+    return tm
+}
+
+private func makeSyncEngine() throws -> SyncEngine {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    let container = try ModelContainer(
+        for: PlaybookModel.self, TaskModel.self, SectionModel.self, WeeklyCycleModel.self, MutationEntry.self,
+        configurations: config
+    )
+    let sessionConfig = URLSessionConfiguration.ephemeral
+    sessionConfig.protocolClasses = [SettingsTestMockURLProtocol.self]
+    let session = URLSession(configuration: sessionConfig)
+    let apiClient = APIClient(baseURL: testBaseURL, session: session)
+    return SyncEngine(apiClient: apiClient, modelContainer: container)
+}
+
+// MARK: - Mock URL Protocol
+
+private final class SettingsTestMockURLProtocol: URLProtocol, @unchecked Sendable {
+
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> (Data, HTTPURLResponse))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = SettingsTestMockURLProtocol.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+        do {
+            let (data, response) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Tests
+
+@Suite("SettingsViewModel", .serialized)
+@MainActor
+struct SettingsViewModelTests {
+
+    @Test("loadEmail populates email from TokenManager")
+    func loadEmailSetsEmail() async throws {
+        let tm = try await makeTokenManager(email: "test@example.com")
+        let vm = SettingsViewModel(
+            tokenManager: tm,
+            authService: MockSettingsAuthService(),
+            syncEngine: nil,
+            onSignOut: {}
+        )
+
+        #expect(vm.email == nil)
+
+        await vm.loadEmail()
+
+        #expect(vm.email == "test@example.com")
+    }
+
+    @Test("appVersion returns non-empty string")
+    func appVersionNotEmpty() {
+        let vm = SettingsViewModel(
+            tokenManager: TokenManager(baseURL: testBaseURL),
+            authService: MockSettingsAuthService(),
+            syncEngine: nil,
+            onSignOut: {}
+        )
+
+        #expect(!vm.appVersion.isEmpty)
+    }
+
+    @Test("syncStatusValue defaults to .synced when no engine")
+    func syncStatusDefaultsSynced() {
+        let vm = SettingsViewModel(
+            tokenManager: TokenManager(baseURL: testBaseURL),
+            authService: MockSettingsAuthService(),
+            syncEngine: nil,
+            onSignOut: {}
+        )
+
+        #expect(vm.syncStatusValue == .synced)
+    }
+
+    @Test("syncStatusValue reflects engine status")
+    func syncStatusReflectsEngine() throws {
+        let engine = try makeSyncEngine()
+        let vm = SettingsViewModel(
+            tokenManager: TokenManager(baseURL: testBaseURL),
+            authService: MockSettingsAuthService(),
+            syncEngine: engine,
+            onSignOut: {}
+        )
+
+        engine.status.value = .offline
+        #expect(vm.syncStatusValue == .offline)
+
+        engine.status.value = .pending(3)
+        #expect(vm.syncStatusValue == .pending(3))
+
+        engine.status.value = .synced
+        #expect(vm.syncStatusValue == .synced)
+    }
+
+    @Test("pendingCount reflects engine queue")
+    func pendingCountReflectsQueue() throws {
+        let engine = try makeSyncEngine()
+        let vm = SettingsViewModel(
+            tokenManager: TokenManager(baseURL: testBaseURL),
+            authService: MockSettingsAuthService(),
+            syncEngine: engine,
+            onSignOut: {}
+        )
+
+        #expect(vm.pendingCount == 0)
+        #expect(vm.hasPendingMutations == false)
+
+        engine.enqueue(
+            path: "/v1/tasks",
+            method: .post,
+            body: nil as CreateTaskDTO?,
+            entityType: "task"
+        )
+
+        #expect(vm.pendingCount == 1)
+        #expect(vm.hasPendingMutations == true)
+    }
+
+    @Test("confirmSignOut shows confirmation when mutations pending")
+    func confirmSignOutShowsDialogWhenPending() throws {
+        let engine = try makeSyncEngine()
+        let vm = SettingsViewModel(
+            tokenManager: TokenManager(baseURL: testBaseURL),
+            authService: MockSettingsAuthService(),
+            syncEngine: engine,
+            onSignOut: {}
+        )
+
+        engine.enqueue(
+            path: "/v1/tasks",
+            method: .post,
+            body: nil as CreateTaskDTO?,
+            entityType: "task"
+        )
+
+        vm.confirmSignOut()
+
+        #expect(vm.showSignOutConfirmation == true)
+    }
+
+    @Test("confirmSignOut calls performSignOut directly when no pending")
+    func confirmSignOutDirectWhenNoPending() {
+        nonisolated(unsafe) var signOutCalled = false
+        let vm = SettingsViewModel(
+            tokenManager: TokenManager(baseURL: testBaseURL),
+            authService: MockSettingsAuthService(),
+            syncEngine: nil,
+            onSignOut: { signOutCalled = true }
+        )
+
+        vm.confirmSignOut()
+
+        #expect(vm.showSignOutConfirmation == false)
+        #expect(signOutCalled == true)
+    }
+
+    @Test("performSignOut fires onSignOut callback")
+    func performSignOutCallsCallback() {
+        nonisolated(unsafe) var signOutCalled = false
+        let vm = SettingsViewModel(
+            tokenManager: TokenManager(baseURL: testBaseURL),
+            authService: MockSettingsAuthService(),
+            syncEngine: nil,
+            onSignOut: { signOutCalled = true }
+        )
+
+        vm.performSignOut()
+
+        #expect(signOutCalled == true)
+    }
+
+    @Test("syncNow sets isSyncing during sync")
+    func syncNowSetsIsSyncing() async throws {
+        SettingsTestMockURLProtocol.handler = { _ in
+            let response = HTTPURLResponse(
+                url: testBaseURL,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (Data(), response)
+        }
+
+        let engine = try makeSyncEngine()
+        let vm = SettingsViewModel(
+            tokenManager: TokenManager(baseURL: testBaseURL),
+            authService: MockSettingsAuthService(),
+            syncEngine: engine,
+            onSignOut: {}
+        )
+
+        #expect(vm.isSyncing == false)
+
+        await vm.syncNow()
+
+        // After sync completes, isSyncing should be false.
+        #expect(vm.isSyncing == false)
+
+        SettingsTestMockURLProtocol.handler = nil
+    }
+
+    @Test("isConnected defaults to true when no engine")
+    func isConnectedDefaultsTrue() {
+        let vm = SettingsViewModel(
+            tokenManager: TokenManager(baseURL: testBaseURL),
+            authService: MockSettingsAuthService(),
+            syncEngine: nil,
+            onSignOut: {}
+        )
+
+        #expect(vm.isConnected == true)
+    }
+
+    @Test("lastSyncText returns nil when never synced")
+    func lastSyncTextNilWhenNeverSynced() {
+        let vm = SettingsViewModel(
+            tokenManager: TokenManager(baseURL: testBaseURL),
+            authService: MockSettingsAuthService(),
+            syncEngine: nil,
+            onSignOut: {}
+        )
+
+        #expect(vm.lastSyncText == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- Created full-screen Settings modal accessible from gear icon in Playbook List
- Account section displays user email loaded from TokenManager
- Sync section shows live status indicator (green/yellow/red/gray dots), last sync timestamp, pending mutation count, and "Sync Now" button
- About section shows app version with links placeholder
- Sign Out button with confirmation dialog when unsynced mutations exist
- Added `lastSyncDate` tracking to SyncEngine for "last synced" display
- Threaded tokenManager, authService, and syncEngine through DI chain (RootView → MainTabView → PlaybookListView → SettingsView)

Closes #30

## Test plan
- [x] 11 new SettingsViewModel unit tests (271 total, all passing)
- [x] `loadEmail` populates email from TokenManager
- [x] `syncStatusValue` reflects SyncEngine status changes
- [x] `pendingCount` and `hasPendingMutations` reflect mutation queue
- [x] `confirmSignOut` shows confirmation dialog when mutations pending
- [x] `confirmSignOut` calls performSignOut directly when queue empty
- [x] `performSignOut` fires onSignOut callback
- [x] `syncNow` sets/clears isSyncing flag
- [x] Build succeeds with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)