### PR TITLE
feat: sync status indicator in Playbook Home nav bar (#31)

### DIFF
--- a/idea-pilot/idea-pilot/Core/Sync/SyncStatusDotView.swift
+++ b/idea-pilot/idea-pilot/Core/Sync/SyncStatusDotView.swift
@@ -1,0 +1,61 @@
+//
+//  SyncStatusDotView.swift
+//  idea-pilot
+//
+//  A small colored dot that reflects the current sync status.
+//  Used in the Playbook Home nav bar and anywhere else a compact
+//  sync indicator is needed.
+//
+
+import SwiftUI
+
+/// A compact sync status indicator rendered as a small colored dot.
+///
+/// States:
+/// - `.synced` — green dot
+/// - `.syncing` — spinning progress indicator
+/// - `.pending` — yellow dot
+/// - `.error` — red dot
+/// - `.offline` — gray dot
+struct SyncStatusDotView: View {
+
+    let status: SyncStatusValue
+    var size: CGFloat = 8
+
+    var body: some View {
+        switch status {
+        case .synced:
+            Circle()
+                .fill(Color.green)
+                .frame(width: size, height: size)
+        case .syncing:
+            ProgressView()
+                .scaleEffect(0.6)
+                .frame(width: size + 4, height: size + 4)
+                .tint(Color.theme.primary)
+        case .pending:
+            Circle()
+                .fill(Color.yellow)
+                .frame(width: size, height: size)
+        case .error:
+            Circle()
+                .fill(Color.theme.destructive)
+                .frame(width: size, height: size)
+        case .offline:
+            Circle()
+                .fill(Color.gray)
+                .frame(width: size, height: size)
+        }
+    }
+
+    /// A human-readable label describing the current status.
+    var statusLabel: String {
+        switch status {
+        case .synced: "Synced"
+        case .syncing: "Syncing"
+        case .pending(let count): "\(count) pending"
+        case .error: "Sync error"
+        case .offline: "Offline"
+        }
+    }
+}

--- a/idea-pilot/idea-pilot/Features/Playbooks/Views/PlaybookListView.swift
+++ b/idea-pilot/idea-pilot/Features/Playbooks/Views/PlaybookListView.swift
@@ -89,6 +89,7 @@ struct PlaybookListView: View {
                     taskService: taskService,
                     sectionService: sectionService,
                     weeklyPlanService: weeklyPlanService,
+                    syncEngine: syncEngine,
                     onArchive: { vm.archivePlaybook(id: playbook.id) }
                 )
             }
@@ -147,6 +148,7 @@ private struct PlaybookCardRow: View {
     let taskService: any TaskServiceProtocol
     let sectionService: any SectionServiceProtocol
     let weeklyPlanService: any WeeklyPlanServiceProtocol
+    let syncEngine: SyncEngine?
     let onArchive: () -> Void
 
     private var nowTaskCount: Int {
@@ -155,7 +157,7 @@ private struct PlaybookCardRow: View {
 
     var body: some View {
         NavigationLink {
-            PlaybookHomeView(vm: PlaybookHomeViewModel(playbook: playbook, taskService: taskService, sectionService: sectionService, weeklyPlanService: weeklyPlanService))
+            PlaybookHomeView(vm: PlaybookHomeViewModel(playbook: playbook, taskService: taskService, sectionService: sectionService, weeklyPlanService: weeklyPlanService, syncEngine: syncEngine))
         } label: {
             HStack(spacing: 12) {
                 VStack(alignment: .leading, spacing: 8) {

--- a/idea-pilot/idea-pilot/Features/Tasks/ViewModels/PlaybookHomeViewModel.swift
+++ b/idea-pilot/idea-pilot/Features/Tasks/ViewModels/PlaybookHomeViewModel.swift
@@ -69,11 +69,26 @@ final class PlaybookHomeViewModel {
         }
     }
 
+    // MARK: - Sync
+
+    /// The current sync status, derived from the SyncEngine.
+    /// Defaults to `.synced` when no engine is available.
+    var syncStatusValue: SyncStatusValue {
+        syncEngine?.status.value ?? .synced
+    }
+
+    /// The error message from the sync engine when status is `.error`.
+    var syncErrorMessage: String? {
+        if case .error(let message) = syncStatusValue { return message }
+        return nil
+    }
+
     // MARK: - Dependencies
 
     let taskService: any TaskServiceProtocol
     let sectionService: any SectionServiceProtocol
     let weeklyPlanService: any WeeklyPlanServiceProtocol
+    let syncEngine: SyncEngine?
 
     // MARK: - Init
 
@@ -84,11 +99,13 @@ final class PlaybookHomeViewModel {
     ///   - taskService: The service for task API calls and persistence.
     ///   - sectionService: The service for section API calls and persistence.
     ///   - weeklyPlanService: The service for weekly plan API calls and persistence.
-    init(playbook: PlaybookModel, taskService: any TaskServiceProtocol, sectionService: any SectionServiceProtocol, weeklyPlanService: any WeeklyPlanServiceProtocol) {
+    ///   - syncEngine: The sync engine for displaying sync status. Pass `nil` when unavailable.
+    init(playbook: PlaybookModel, taskService: any TaskServiceProtocol, sectionService: any SectionServiceProtocol, weeklyPlanService: any WeeklyPlanServiceProtocol, syncEngine: SyncEngine? = nil) {
         self.playbook = playbook
         self.taskService = taskService
         self.sectionService = sectionService
         self.weeklyPlanService = weeklyPlanService
+        self.syncEngine = syncEngine
     }
 
     // MARK: - Actions
@@ -229,6 +246,11 @@ final class PlaybookHomeViewModel {
     /// Clears the selected task, dismissing the detail sheet.
     func clearSelectedTask() {
         selectedTask = nil
+    }
+
+    /// Retries sync when the user taps the error indicator.
+    func retrySync() {
+        Task { await syncEngine?.onPullToRefresh() }
     }
 
     // MARK: - Private

--- a/idea-pilot/idea-pilot/Features/Tasks/Views/PlaybookHomeView.swift
+++ b/idea-pilot/idea-pilot/Features/Tasks/Views/PlaybookHomeView.swift
@@ -25,6 +25,7 @@ struct PlaybookHomeView: View {
 
     @State private var showSections = false
     @State private var showWeeklyPlan = false
+    @State private var showSyncError = false
 
     // MARK: - Reorder State
 
@@ -59,6 +60,10 @@ struct PlaybookHomeView: View {
         .navigationTitle(vm.playbook.title)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                syncIndicator
+            }
+
             ToolbarItem(placement: .topBarTrailing) {
                 Menu {
                     Button {
@@ -78,6 +83,12 @@ struct PlaybookHomeView: View {
                 }
                 .accessibilityLabel("More options")
             }
+        }
+        .alert("Sync Error", isPresented: $showSyncError) {
+            Button("Retry") { vm.retrySync() }
+            Button("Dismiss", role: .cancel) {}
+        } message: {
+            Text(vm.syncErrorMessage ?? "An error occurred while syncing.")
         }
         .navigationDestination(isPresented: $showSections) {
             SectionsListView(vm: SectionsViewModel(
@@ -283,6 +294,21 @@ struct PlaybookHomeView: View {
         )
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Error: \(message)")
+    }
+
+    // MARK: - Sync Indicator
+
+    @ViewBuilder
+    private var syncIndicator: some View {
+        let dot = SyncStatusDotView(status: vm.syncStatusValue)
+            .accessibilityLabel("Sync status: \(SyncStatusDotView(status: vm.syncStatusValue).statusLabel)")
+
+        if case .error = vm.syncStatusValue {
+            Button { showSyncError = true } label: { dot }
+                .accessibilityHint("Tap to see error details and retry")
+        } else {
+            dot
+        }
     }
 }
 

--- a/idea-pilot/idea-pilotTests/PlaybookHomeViewModelTests.swift
+++ b/idea-pilot/idea-pilotTests/PlaybookHomeViewModelTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftData
 import Testing
 @testable import idea_pilot
 
@@ -338,4 +339,59 @@ struct PlaybookHomeViewModelTests {
         vm.clearSelectedTask()
         #expect(vm.selectedTask == nil)
     }
+
+    // MARK: - Sync Status
+
+    @Test("syncStatusValue defaults to .synced when no engine")
+    @MainActor func syncStatusDefaultsSynced() {
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: MockTaskService(), sectionService: StubSectionService(), weeklyPlanService: StubWeeklyPlanService())
+
+        #expect(vm.syncStatusValue == .synced)
+    }
+
+    @Test("syncStatusValue reflects engine status")
+    @MainActor func syncStatusReflectsEngine() throws {
+        let engine = try makeSyncEngineForHomeTests()
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: MockTaskService(), sectionService: StubSectionService(), weeklyPlanService: StubWeeklyPlanService(), syncEngine: engine)
+
+        engine.status.value = .offline
+        #expect(vm.syncStatusValue == .offline)
+
+        engine.status.value = .pending(3)
+        #expect(vm.syncStatusValue == .pending(3))
+
+        engine.status.value = .error("Network failure")
+        #expect(vm.syncStatusValue == .error("Network failure"))
+
+        engine.status.value = .synced
+        #expect(vm.syncStatusValue == .synced)
+    }
+
+    @Test("syncErrorMessage returns message for error status")
+    @MainActor func syncErrorMessage() throws {
+        let engine = try makeSyncEngineForHomeTests()
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: MockTaskService(), sectionService: StubSectionService(), weeklyPlanService: StubWeeklyPlanService(), syncEngine: engine)
+
+        #expect(vm.syncErrorMessage == nil)
+
+        engine.status.value = .error("Connection refused")
+        #expect(vm.syncErrorMessage == "Connection refused")
+
+        engine.status.value = .synced
+        #expect(vm.syncErrorMessage == nil)
+    }
+}
+
+// MARK: - Sync Engine Helper
+
+private let homeTestBaseURL = URL(string: "https://api.test.ideapilot.app")!
+
+private func makeSyncEngineForHomeTests() throws -> SyncEngine {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    let container = try ModelContainer(
+        for: PlaybookModel.self, TaskModel.self, SectionModel.self, WeeklyCycleModel.self, MutationEntry.self,
+        configurations: config
+    )
+    let apiClient = APIClient(baseURL: homeTestBaseURL, session: URLSession.shared)
+    return SyncEngine(apiClient: apiClient, modelContainer: container)
 }


### PR DESCRIPTION
## Summary
- Created `SyncStatusDotView` — a reusable compact colored dot reflecting sync state (green/spinner/yellow/red/gray)
- Added `syncEngine` dependency to `PlaybookHomeViewModel` with computed `syncStatusValue` and `syncErrorMessage`
- Added sync dot to Playbook Home toolbar (`.topBarLeading` placement)
- Tapping the red error dot shows an alert with error details and a Retry button
- Threaded `syncEngine` from `PlaybookListView` through `PlaybookCardRow` to `PlaybookHomeViewModel`

Closes #31

## Test plan
- [x] 3 new tests added to PlaybookHomeViewModelTests (274 total, all passing)
- [x] `syncStatusDefaultsSynced` — defaults to `.synced` when no engine
- [x] `syncStatusReflectsEngine` — mirrors engine status changes (offline, pending, error, synced)
- [x] `syncErrorMessage` — returns error message or nil based on status
- [x] Build succeeds with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)