### PR TITLE
feat: optimistic update visual patterns (#33)

### DIFF
--- a/idea-pilot/idea-pilot/Core/Sync/EntitySyncState.swift
+++ b/idea-pilot/idea-pilot/Core/Sync/EntitySyncState.swift
@@ -1,0 +1,24 @@
+//
+//  EntitySyncState.swift
+//  idea-pilot
+//
+//  Per-entity sync state for optimistic update visual indicators.
+//  Used by views to show pending/failed indicators on individual items.
+//
+
+import Foundation
+
+/// The sync state of a specific entity (task, playbook, section, etc.)
+/// as observed by the UI for per-item indicators.
+///
+/// Derived from the `MutationQueue`'s knowledge of pending entries.
+/// Views use this to show subtle sync/warning icons on affected items.
+enum EntitySyncState: Equatable, Sendable {
+    /// One or more mutations are queued and waiting to send.
+    case pending
+    /// A mutation is actively being sent to the server.
+    case inFlight
+    /// The last sync attempt failed. `retryCount` indicates how many
+    /// times the mutation has been retried.
+    case failed(retryCount: Int)
+}

--- a/idea-pilot/idea-pilot/Core/Sync/MutationQueue.swift
+++ b/idea-pilot/idea-pilot/Core/Sync/MutationQueue.swift
@@ -26,6 +26,11 @@ final class MutationQueue {
     /// The number of pending mutations in the queue (observable by views).
     var pendingCount: Int = 0
 
+    /// Per-entity sync states, keyed by entityId.
+    /// Views observe this to show pending/failed indicators on specific items.
+    /// Only entities with non-nil entityId are tracked.
+    var entityStates: [String: EntitySyncState] = [:]
+
     /// Creates a MutationQueue.
     ///
     /// - Parameter modelContainer: The SwiftData container for persistence.
@@ -60,6 +65,9 @@ final class MutationQueue {
         )
         context.insert(entry)
         try context.save()
+        if let entityId {
+            entityStates[entityId] = .pending
+        }
         refreshPendingCount()
     }
 
@@ -90,13 +98,20 @@ final class MutationQueue {
     func markInFlight(_ entry: MutationEntry) throws {
         entry.status = .inFlight
         try modelContainer.mainContext.save()
+        if let entityId = entry.entityId {
+            entityStates[entityId] = .inFlight
+        }
     }
 
     /// Removes a successfully sent mutation from the queue.
     func remove(_ entry: MutationEntry) throws {
+        let entityId = entry.entityId
         let context = modelContainer.mainContext
         context.delete(entry)
         try context.save()
+        if let entityId, !hasPendingEntries(forEntityId: entityId) {
+            entityStates.removeValue(forKey: entityId)
+        }
         refreshPendingCount()
     }
 
@@ -108,12 +123,19 @@ final class MutationQueue {
         entry.retryCount += 1
         entry.lastAttemptAt = .now
         if entry.retryCount >= entry.maxRetries {
+            let entityId = entry.entityId
             let context = modelContainer.mainContext
             context.delete(entry)
             try context.save()
+            if let entityId, !hasPendingEntries(forEntityId: entityId) {
+                entityStates.removeValue(forKey: entityId)
+            }
         } else {
             entry.status = .pending
             try modelContainer.mainContext.save()
+            if let entityId = entry.entityId {
+                entityStates[entityId] = .failed(retryCount: entry.retryCount)
+            }
         }
         refreshPendingCount()
     }
@@ -137,6 +159,7 @@ final class MutationQueue {
         if !stale.isEmpty {
             try context.save()
         }
+        refreshEntityStates()
         refreshPendingCount()
     }
 
@@ -154,9 +177,62 @@ final class MutationQueue {
             try context.save()
         }
         pendingCount = 0
+        entityStates.removeAll()
     }
 
     // MARK: - Private
+
+    /// Returns true if any entries exist in the queue for the given entityId.
+    private func hasPendingEntries(forEntityId entityId: String) -> Bool {
+        let context = modelContainer.mainContext
+        let predicate = #Predicate<MutationEntry> { $0.entityId == entityId }
+        let descriptor = FetchDescriptor(predicate: predicate)
+        return (try? context.fetchCount(descriptor)) ?? 0 > 0
+    }
+
+    /// Rebuilds the `entityStates` dictionary from all persisted entries.
+    ///
+    /// Called on app launch recovery to ensure the dictionary matches
+    /// the persisted SwiftData state after a crash.
+    private func refreshEntityStates() {
+        let context = modelContainer.mainContext
+        let descriptor = FetchDescriptor<MutationEntry>()
+        guard let entries = try? context.fetch(descriptor) else { return }
+
+        var newStates: [String: EntitySyncState] = [:]
+        for entry in entries {
+            guard let entityId = entry.entityId else { continue }
+            let entryState: EntitySyncState = {
+                if entry.retryCount > 0 && entry.status == .pending {
+                    return .failed(retryCount: entry.retryCount)
+                } else if entry.status == .inFlight {
+                    return .inFlight
+                } else {
+                    return .pending
+                }
+            }()
+
+            if let existing = newStates[entityId] {
+                newStates[entityId] = Self.worseState(existing, entryState)
+            } else {
+                newStates[entityId] = entryState
+            }
+        }
+        entityStates = newStates
+    }
+
+    /// Returns the worse of two entity sync states for display purposes.
+    /// Priority: .failed > .inFlight > .pending
+    private static func worseState(_ a: EntitySyncState, _ b: EntitySyncState) -> EntitySyncState {
+        func priority(_ state: EntitySyncState) -> Int {
+            switch state {
+            case .pending: 0
+            case .inFlight: 1
+            case .failed: 2
+            }
+        }
+        return priority(a) >= priority(b) ? a : b
+    }
 
     private func refreshPendingCount() {
         let context = modelContainer.mainContext

--- a/idea-pilot/idea-pilot/Features/Tasks/ViewModels/PlaybookHomeViewModel.swift
+++ b/idea-pilot/idea-pilot/Features/Tasks/ViewModels/PlaybookHomeViewModel.swift
@@ -83,6 +83,20 @@ final class PlaybookHomeViewModel {
         return nil
     }
 
+    /// Returns the sync state for a specific task, or `nil` if fully synced.
+    ///
+    /// Reads from `SyncEngine.mutationQueue.entityStates`, which is
+    /// `@Observable`. SwiftUI views that call this will automatically
+    /// re-render when the dictionary changes.
+    func taskSyncState(for taskId: String) -> EntitySyncState? {
+        syncEngine?.mutationQueue.entityStates[taskId]
+    }
+
+    /// Retries syncing a specific failed task by triggering a queue drain.
+    func retryTaskSync(for taskId: String) {
+        syncEngine?.triggerDrain()
+    }
+
     // MARK: - Dependencies
 
     let taskService: any TaskServiceProtocol

--- a/idea-pilot/idea-pilot/Features/Tasks/Views/PlaybookHomeView.swift
+++ b/idea-pilot/idea-pilot/Features/Tasks/Views/PlaybookHomeView.swift
@@ -160,9 +160,11 @@ struct PlaybookHomeView: View {
                     showCheckbox: vm.selectedLane != .later,
                     currentLane: vm.selectedLane,
                     isDragReordering: draggingTaskId != nil,
+                    syncState: vm.taskSyncState(for: task.id),
                     onTap: { vm.selectTask(task) },
                     onComplete: { vm.completeTask(id: task.id) },
-                    onMove: { lane in vm.moveTask(id: task.id, toLane: lane) }
+                    onMove: { lane in vm.moveTask(id: task.id, toLane: lane) },
+                    onRetrySync: { vm.retryTaskSync(for: task.id) }
                 )
                 .scaleEffect(isDragging ? 1.02 : 1.0)
                 .shadow(
@@ -352,9 +354,11 @@ private struct TaskCardRow: View {
     let showCheckbox: Bool
     let currentLane: TaskLane
     let isDragReordering: Bool
+    var syncState: EntitySyncState? = nil
     let onTap: () -> Void
     let onComplete: () -> Void
     let onMove: (TaskLane) -> Void
+    var onRetrySync: (() -> Void)? = nil
 
     // MARK: - Swipe State
 
@@ -437,12 +441,42 @@ private struct TaskCardRow: View {
 
                 Spacer()
 
+                if let syncState {
+                    syncIndicator(for: syncState)
+                }
+
                 TimeEstimatePill(minutes: task.estimatedMinutes)
             }
             .padding(16)
             .cardStyle()
         }
         .buttonStyle(.pressable)
+    }
+
+    // MARK: - Sync Indicator
+
+    @ViewBuilder
+    private func syncIndicator(for state: EntitySyncState) -> some View {
+        switch state {
+        case .pending, .inFlight:
+            Image(systemName: "arrow.triangle.2.circlepath")
+                .font(.system(size: 12))
+                .foregroundStyle(Color.theme.mutedForeground.opacity(0.6))
+                .accessibilityLabel("Syncing")
+                .accessibilityHint("This change is waiting to sync")
+
+        case .failed:
+            Button {
+                onRetrySync?()
+            } label: {
+                Image(systemName: "exclamationmark.arrow.triangle.2.circlepath")
+                    .font(.system(size: 14))
+                    .foregroundStyle(Color.theme.destructive.opacity(0.8))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Sync failed")
+            .accessibilityHint("Tap to retry syncing this change")
+        }
     }
 
     // MARK: - Checkbox

--- a/idea-pilot/idea-pilotTests/PlaybookHomeViewModelTests.swift
+++ b/idea-pilot/idea-pilotTests/PlaybookHomeViewModelTests.swift
@@ -380,6 +380,35 @@ struct PlaybookHomeViewModelTests {
         engine.status.value = .synced
         #expect(vm.syncErrorMessage == nil)
     }
+
+    // MARK: - Per-Item Sync State
+
+    @Test("taskSyncState returns nil when no sync engine")
+    @MainActor func taskSyncStateWithoutEngine() {
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: MockTaskService(), sectionService: StubSectionService(), weeklyPlanService: StubWeeklyPlanService())
+        #expect(vm.taskSyncState(for: "t-1") == nil)
+    }
+
+    @Test("taskSyncState returns state from mutation queue entityStates")
+    @MainActor func taskSyncStateFromQueue() throws {
+        let engine = try makeSyncEngineForHomeTests()
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: MockTaskService(), sectionService: StubSectionService(), weeklyPlanService: StubWeeklyPlanService(), syncEngine: engine)
+
+        engine.mutationQueue.entityStates["t-1"] = .pending
+
+        #expect(vm.taskSyncState(for: "t-1") == .pending)
+        #expect(vm.taskSyncState(for: "t-2") == nil)
+    }
+
+    @Test("taskSyncState returns .failed state from mutation queue")
+    @MainActor func taskSyncStateReturnsFailed() throws {
+        let engine = try makeSyncEngineForHomeTests()
+        let vm = PlaybookHomeViewModel(playbook: makeSamplePlaybook(), taskService: MockTaskService(), sectionService: StubSectionService(), weeklyPlanService: StubWeeklyPlanService(), syncEngine: engine)
+
+        engine.mutationQueue.entityStates["t-1"] = .failed(retryCount: 2)
+
+        #expect(vm.taskSyncState(for: "t-1") == .failed(retryCount: 2))
+    }
 }
 
 // MARK: - Sync Engine Helper

--- a/idea-pilot/idea-pilotTests/SyncEngineTests.swift
+++ b/idea-pilot/idea-pilotTests/SyncEngineTests.swift
@@ -267,6 +267,186 @@ struct MutationQueueTests {
 
         #expect(queue.pendingCount == 0)
     }
+
+    // MARK: - EntityStates Dictionary
+
+    @Test("enqueue sets entityStates to .pending for entity with ID")
+    func enqueueSetsEntityStatePending() throws {
+        let container = try makeInMemoryModelContainer()
+        let queue = MutationQueue(modelContainer: container)
+
+        try queue.enqueue(
+            path: "/v1/tasks/task-1",
+            method: .patch,
+            bodyData: Data("{}".utf8),
+            entityType: "task",
+            entityId: "task-1"
+        )
+
+        #expect(queue.entityStates["task-1"] == .pending)
+    }
+
+    @Test("enqueue without entityId does not add to entityStates")
+    func enqueueWithoutIdSkipsEntityStates() throws {
+        let container = try makeInMemoryModelContainer()
+        let queue = MutationQueue(modelContainer: container)
+
+        try queue.enqueue(
+            path: "/v1/tasks/reorder",
+            method: .post,
+            bodyData: Data("{}".utf8),
+            entityType: "task",
+            entityId: nil
+        )
+
+        #expect(queue.entityStates.isEmpty)
+    }
+
+    @Test("markInFlight transitions entityStates to .inFlight")
+    func markInFlightUpdatesEntityStates() throws {
+        let container = try makeInMemoryModelContainer()
+        let queue = MutationQueue(modelContainer: container)
+
+        try queue.enqueue(
+            path: "/v1/tasks/task-1",
+            method: .patch,
+            bodyData: nil,
+            entityType: "task",
+            entityId: "task-1"
+        )
+
+        let entry = try queue.peek()!
+        try queue.markInFlight(entry)
+
+        #expect(queue.entityStates["task-1"] == .inFlight)
+    }
+
+    @Test("remove clears entityStates when no remaining entries")
+    func removeRemovesEntityState() throws {
+        let container = try makeInMemoryModelContainer()
+        let queue = MutationQueue(modelContainer: container)
+
+        try queue.enqueue(
+            path: "/v1/tasks/task-1",
+            method: .patch,
+            bodyData: nil,
+            entityType: "task",
+            entityId: "task-1"
+        )
+
+        let entry = try queue.peek()!
+        try queue.remove(entry)
+
+        #expect(queue.entityStates["task-1"] == nil)
+    }
+
+    @Test("remove preserves entityStates when other entries remain for same entity")
+    func removeKeepsStateWhenOtherEntriesRemain() throws {
+        let container = try makeInMemoryModelContainer()
+        let queue = MutationQueue(modelContainer: container)
+
+        try queue.enqueue(
+            path: "/v1/tasks/task-1",
+            method: .patch,
+            bodyData: Data("{\"title\":\"A\"}".utf8),
+            entityType: "task",
+            entityId: "task-1"
+        )
+        try queue.enqueue(
+            path: "/v1/tasks/task-1",
+            method: .patch,
+            bodyData: Data("{\"lane\":\"NOW\"}".utf8),
+            entityType: "task",
+            entityId: "task-1"
+        )
+
+        let all = try queue.allPending()
+        let first = all.first!
+        try queue.remove(first)
+
+        #expect(queue.entityStates["task-1"] != nil)
+    }
+
+    @Test("markFailed sets entityStates to .failed with retryCount")
+    func markFailedSetsFailedState() throws {
+        let container = try makeInMemoryModelContainer()
+        let queue = MutationQueue(modelContainer: container)
+
+        try queue.enqueue(
+            path: "/v1/tasks/task-1",
+            method: .patch,
+            bodyData: nil,
+            entityType: "task",
+            entityId: "task-1"
+        )
+
+        let entry = try queue.peek()!
+        try queue.markInFlight(entry)
+        try queue.markFailed(entry)
+
+        #expect(queue.entityStates["task-1"] == .failed(retryCount: 1))
+    }
+
+    @Test("markFailed removes entityState when entry discarded after maxRetries")
+    func markFailedRemovesStateAfterMaxRetries() throws {
+        let container = try makeInMemoryModelContainer()
+        let queue = MutationQueue(modelContainer: container)
+
+        let context = container.mainContext
+        let entry = MutationEntry(
+            endpointPath: "/v1/tasks/task-1",
+            httpMethod: .patch,
+            entityType: "task",
+            entityId: "task-1",
+            retryCount: 4,
+            maxRetries: 5
+        )
+        context.insert(entry)
+        try context.save()
+        queue.entityStates["task-1"] = .failed(retryCount: 4)
+
+        try queue.markFailed(entry)
+
+        #expect(queue.entityStates["task-1"] == nil)
+    }
+
+    @Test("purge clears all entityStates")
+    func purgeClearsEntityStates() throws {
+        let container = try makeInMemoryModelContainer()
+        let queue = MutationQueue(modelContainer: container)
+
+        try queue.enqueue(path: "/v1/tasks/t-1", method: .patch, bodyData: nil, entityType: "task", entityId: "t-1")
+        try queue.enqueue(path: "/v1/tasks/t-2", method: .patch, bodyData: nil, entityType: "task", entityId: "t-2")
+
+        #expect(queue.entityStates.count == 2)
+
+        try queue.purge()
+
+        #expect(queue.entityStates.isEmpty)
+    }
+
+    @Test("resetInFlightToPending rebuilds entityStates from persisted entries")
+    func resetInFlightRebuildsEntityStates() throws {
+        let container = try makeInMemoryModelContainer()
+        let queue = MutationQueue(modelContainer: container)
+
+        let context = container.mainContext
+        let entry = MutationEntry(
+            endpointPath: "/v1/tasks/task-1",
+            httpMethod: .patch,
+            entityType: "task",
+            entityId: "task-1",
+            status: .inFlight
+        )
+        context.insert(entry)
+        try context.save()
+
+        #expect(queue.entityStates.isEmpty)
+
+        try queue.resetInFlightToPending()
+
+        #expect(queue.entityStates["task-1"] == .pending)
+    }
 }
 
 // MARK: - SyncEngine Tests


### PR DESCRIPTION
## Summary
- Added `EntitySyncState` enum (`.pending`, `.inFlight`, `.failed`) for per-entity sync tracking
- Added observable `entityStates` dictionary to `MutationQueue`, updated across all lifecycle methods (enqueue, markInFlight, remove, markFailed, purge, resetInFlightToPending)
- Added `taskSyncState(for:)` and `retryTaskSync(for:)` to `PlaybookHomeViewModel`
- Added subtle sync indicator on task cards — muted sync icon for pending, destructive warning icon (tappable for retry) for failed
- 12 new unit tests covering dictionary lifecycle and ViewModel pass-through

## Test plan
- [x] Build succeeds with zero errors
- [x] All 12 new tests pass (9 MutationQueue entityStates + 3 ViewModel taskSyncState)
- [x] All existing tests continue to pass
- [ ] Visual check: pending indicator appears on task cards when mutations are queued offline
- [ ] Visual check: failed indicator appears after sync failure, tap triggers retry

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)