### PR TITLE
feat: accessibility audit — labels, Dynamic Type, VoiceOver (#35)

### DIFF
--- a/idea-pilot/idea-pilot/Core/Components/EmptyStateView.swift
+++ b/idea-pilot/idea-pilot/Core/Components/EmptyStateView.swift
@@ -50,12 +50,13 @@ struct EmptyStateView: View {
                         .fontWeight(.semibold)
                         .foregroundStyle(Color.theme.primaryForeground)
                         .frame(maxWidth: .infinity)
-                        .frame(height: 50)
+                        .frame(minHeight: 50)
                         .background(Color.theme.primary)
                         .clipShape(RoundedRectangle(cornerRadius: .theme.radiusMd))
                         .shadow(color: Color.theme.primary.opacity(0.4), radius: 12, y: 4)
                 }
                 .buttonStyle(.pressable)
+                .accessibilityLabel(actionTitle)
                 .padding(.horizontal, 24)
             }
         }

--- a/idea-pilot/idea-pilot/Core/Sync/SyncStatusDotView.swift
+++ b/idea-pilot/idea-pilot/Core/Sync/SyncStatusDotView.swift
@@ -23,6 +23,12 @@ struct SyncStatusDotView: View {
     var size: CGFloat = 8
 
     var body: some View {
+        dotView
+            .accessibilityLabel(statusLabel)
+    }
+
+    @ViewBuilder
+    private var dotView: some View {
         switch status {
         case .synced:
             Circle()

--- a/idea-pilot/idea-pilot/Features/Auth/Views/AuthView.swift
+++ b/idea-pilot/idea-pilot/Features/Auth/Views/AuthView.swift
@@ -155,7 +155,7 @@ struct AuthView: View {
                 }
             }
             .frame(maxWidth: .infinity)
-            .frame(height: 50)
+            .frame(minHeight: 50)
             .foregroundStyle(Color.theme.primaryForeground)
             .background(Color.theme.primary)
             .clipShape(RoundedRectangle(cornerRadius: .theme.radiusMd))

--- a/idea-pilot/idea-pilot/Features/Playbooks/Views/PlaybookListView.swift
+++ b/idea-pilot/idea-pilot/Features/Playbooks/Views/PlaybookListView.swift
@@ -303,7 +303,7 @@ private struct CreatePlaybookSheet: View {
                             .fontWeight(.semibold)
                             .foregroundStyle(Color.theme.primaryForeground)
                             .frame(maxWidth: .infinity)
-                            .frame(height: 50)
+                            .frame(minHeight: 50)
                             .background(isTitleEmpty ? Color.theme.muted : Color.theme.primary)
                             .clipShape(RoundedRectangle(cornerRadius: .theme.radiusMd))
                             .shadow(

--- a/idea-pilot/idea-pilot/Features/Settings/Views/SettingsView.swift
+++ b/idea-pilot/idea-pilot/Features/Settings/Views/SettingsView.swift
@@ -235,7 +235,7 @@ struct SettingsView: View {
                 .fontWeight(.semibold)
                 .foregroundStyle(Color.theme.destructive)
                 .frame(maxWidth: .infinity)
-                .frame(height: 50)
+                .frame(minHeight: 50)
                 .background(Color.theme.destructive.opacity(0.1))
                 .clipShape(RoundedRectangle(cornerRadius: .theme.radiusMd))
                 .overlay(

--- a/idea-pilot/idea-pilot/Features/Tasks/Views/PlaybookHomeView.swift
+++ b/idea-pilot/idea-pilot/Features/Tasks/Views/PlaybookHomeView.swift
@@ -707,7 +707,7 @@ private struct AddTaskButton: View {
             }
             .foregroundStyle(Color.theme.mutedForeground)
             .frame(maxWidth: .infinity)
-            .frame(height: 56)
+            .frame(minHeight: 56)
             .background(Color.clear)
             .clipShape(RoundedRectangle(cornerRadius: .theme.radiusLg))
             .overlay(

--- a/idea-pilot/idea-pilot/Features/Tasks/Views/QuickAddSheet.swift
+++ b/idea-pilot/idea-pilot/Features/Tasks/Views/QuickAddSheet.swift
@@ -202,7 +202,7 @@ struct QuickAddSheet: View {
                 .fontWeight(.semibold)
                 .foregroundStyle(Color.theme.primaryForeground)
                 .frame(maxWidth: .infinity)
-                .frame(height: 50)
+                .frame(minHeight: 50)
                 .background(vm.canSubmit ? Color.theme.primary : Color.theme.muted)
                 .clipShape(RoundedRectangle(cornerRadius: .theme.radiusMd))
                 .shadow(

--- a/idea-pilot/idea-pilot/Features/Tasks/Views/TaskDetailSheet.swift
+++ b/idea-pilot/idea-pilot/Features/Tasks/Views/TaskDetailSheet.swift
@@ -232,7 +232,7 @@ struct TaskDetailSheet: View {
                 .fontWeight(.semibold)
                 .foregroundStyle(Color.theme.accentForeground)
                 .frame(maxWidth: .infinity)
-                .frame(height: 50)
+                .frame(minHeight: 50)
                 .background(Color.theme.accent)
                 .clipShape(RoundedRectangle(cornerRadius: .theme.radiusMd))
                 .shadow(color: Color.theme.accent.opacity(0.4), radius: 12, y: 4)
@@ -251,7 +251,7 @@ struct TaskDetailSheet: View {
                 .fontWeight(.semibold)
                 .foregroundStyle(Color.theme.destructive)
                 .frame(maxWidth: .infinity)
-                .frame(height: 50)
+                .frame(minHeight: 50)
                 .background(Color.clear)
                 .clipShape(RoundedRectangle(cornerRadius: .theme.radiusMd))
                 .overlay(

--- a/idea-pilot/idea-pilot/Features/WeeklyPlan/Views/WeeklyPlanFlowView.swift
+++ b/idea-pilot/idea-pilot/Features/WeeklyPlan/Views/WeeklyPlanFlowView.swift
@@ -735,7 +735,7 @@ private struct PrimaryActionButton: View {
             }
             .foregroundStyle(Color.theme.primaryForeground)
             .frame(maxWidth: .infinity)
-            .frame(height: 50)
+            .frame(minHeight: 50)
             .background(isEnabled ? Color.theme.primary : Color.theme.muted)
             .clipShape(RoundedRectangle(cornerRadius: .theme.radiusMd))
             .shadow(

--- a/idea-pilot/idea-pilot/Navigation/MainTabView.swift
+++ b/idea-pilot/idea-pilot/Navigation/MainTabView.swift
@@ -169,6 +169,8 @@ private struct CustomTabBar: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("\(tab.label) tab")
+        .accessibilityAddTraits(selectedTab == tab ? .isSelected : [])
     }
 
     // MARK: - Capture Button (Center)
@@ -186,6 +188,7 @@ private struct CustomTabBar: View {
                 .shadow(color: Color.theme.primary.opacity(0.4), radius: 8, y: 2)
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("Create new task")
         .offset(y: -8)
     }
 }
@@ -218,6 +221,7 @@ private struct NowPlaceholderView: View {
                         .font(.theme.body)
                         .foregroundStyle(Color.theme.destructive)
                 }
+                .accessibilityLabel("Sign out")
             }
         }
         .safeAreaPadding(.bottom, 72)

--- a/idea-pilot/idea-pilot/Navigation/RootView.swift
+++ b/idea-pilot/idea-pilot/Navigation/RootView.swift
@@ -64,6 +64,7 @@ struct RootView: View {
                     .background(Color.theme.primary)
                     .clipShape(RoundedRectangle(cornerRadius: .theme.radiusLg))
                     .shadow(color: Color.theme.primary.opacity(0.5), radius: 20, y: 4)
+                    .accessibilityHidden(true)
 
                 Text("Idea Pilot")
                     .font(.theme.largeTitle)


### PR DESCRIPTION
## Summary
- Add missing `accessibilityLabel` to MainTabView tab buttons, capture button, and sign-out button
- Add intrinsic `accessibilityLabel` to `SyncStatusDotView` so it's self-labeling regardless of call site
- Add `accessibilityLabel` to `EmptyStateView` action button
- Mark `RootView` splash logo as `.accessibilityHidden(true)`
- Replace `.frame(height: 50)` with `.frame(minHeight: 50)` on action buttons across 8 files so they expand vertically with large Dynamic Type sizes
- Add `.accessibilityAddTraits(.isSelected)` to active tab button for VoiceOver

## Test plan
- [x] Build succeeds (zero errors)
- [x] All 298 tests pass
- [ ] VoiceOver: tab bar announces "Now tab, selected", "Playbooks tab", "Create new task"
- [ ] Dynamic Type: set to AX5, verify buttons expand vertically without clipping

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)