### PR TITLE
feat: spring animations and interaction polish (#36)

### DIFF
--- a/idea-pilot/idea-pilot/Core/Extensions/View+Theme.swift
+++ b/idea-pilot/idea-pilot/Core/Extensions/View+Theme.swift
@@ -23,7 +23,12 @@ struct PressableButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .scaleEffect(configuration.isPressed ? 0.98 : 1.0)
-            .animation(.spring(response: 0.3, dampingFraction: 0.7), value: configuration.isPressed)
+            .animation(
+                UIAccessibility.isReduceMotionEnabled
+                    ? nil
+                    : .spring(response: 0.3, dampingFraction: 0.7),
+                value: configuration.isPressed
+            )
     }
 }
 

--- a/idea-pilot/idea-pilot/Features/Tasks/ViewModels/QuickAddViewModel.swift
+++ b/idea-pilot/idea-pilot/Features/Tasks/ViewModels/QuickAddViewModel.swift
@@ -121,7 +121,7 @@ final class QuickAddViewModel {
                 // Trigger success flash.
                 showSuccessFlash = true
                 Task {
-                    try? await Task.sleep(for: .milliseconds(800))
+                    try? await Task.sleep(for: .milliseconds(300))
                     showSuccessFlash = false
                 }
             } catch let error as TaskError {

--- a/idea-pilot/idea-pilot/Features/Tasks/Views/PlaybookHomeView.swift
+++ b/idea-pilot/idea-pilot/Features/Tasks/Views/PlaybookHomeView.swift
@@ -341,7 +341,7 @@ private struct LaneSegmentedControl: View {
         .padding(4)
         .background(Color.theme.secondary)
         .clipShape(RoundedRectangle(cornerRadius: .theme.radiusMd))
-        .motionSafe(.spring(response: 0.3, dampingFraction: 0.8))
+        .motionSafe(.spring(duration: 0.6, bounce: 0.2))
     }
 }
 

--- a/idea-pilot/idea-pilot/Navigation/MainTabView.swift
+++ b/idea-pilot/idea-pilot/Navigation/MainTabView.swift
@@ -130,6 +130,7 @@ private struct CustomTabBar: View {
 
     @Binding var selectedTab: AppTab
     var onCaptureTap: () -> Void
+    @State private var tappedTab: AppTab?
 
     var body: some View {
         HStack {
@@ -153,6 +154,7 @@ private struct CustomTabBar: View {
 
     private func tabButton(_ tab: AppTab) -> some View {
         Button {
+            tappedTab = tab
             selectedTab = tab
         } label: {
             VStack(spacing: 4) {
@@ -165,10 +167,21 @@ private struct CustomTabBar: View {
                 }
             }
             .foregroundStyle(selectedTab == tab ? Color.theme.primary : Color.theme.mutedForeground)
+            .scaleEffect(tappedTab == tab ? 0.85 : 1.0)
             .frame(minWidth: 56, minHeight: 44)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .onChange(of: tappedTab) { _, newValue in
+            if newValue == tab {
+                let animation: Animation? = UIAccessibility.isReduceMotionEnabled
+                    ? nil
+                    : .spring(response: 0.3, dampingFraction: 0.5)
+                withAnimation(animation) {
+                    tappedTab = nil
+                }
+            }
+        }
         .accessibilityLabel("\(tab.label) tab")
         .accessibilityAddTraits(selectedTab == tab ? .isSelected : [])
     }

--- a/idea-pilot/idea-pilotTests/QuickAddViewModelTests.swift
+++ b/idea-pilot/idea-pilotTests/QuickAddViewModelTests.swift
@@ -212,8 +212,8 @@ struct QuickAddViewModelTests {
         try await Task.sleep(for: .milliseconds(50))
         #expect(vm.showSuccessFlash == true)
 
-        // Wait for flash to auto-dismiss.
-        try await Task.sleep(for: .milliseconds(1000))
+        // Wait for flash to auto-dismiss (300ms flash + margin).
+        try await Task.sleep(for: .milliseconds(500))
         #expect(vm.showSuccessFlash == false)
     }
 


### PR DESCRIPTION
## Summary
- Fix `PressableButtonStyle` to respect Reduce Motion — animation becomes `nil` when accessibility setting is enabled
- Tune `LaneSegmentedControl` pill spring from `(response: 0.3, dampingFraction: 0.8)` to `(duration: 0.6, bounce: 0.2)` for a bouncier, more playful feel
- Reduce Quick Add success flash duration from 800ms to 300ms for snappier feedback
- Add subtle scale-bounce animation (0.85 → 1.0 spring) on tab bar button taps, with Reduce Motion support
- Sheet presentations left as default iOS — SwiftUI doesn't expose custom presentation curves

## Test plan
- [x] Build succeeds (zero errors)
- [x] All tests pass (flash auto-dismiss test updated for 300ms timing)
- [ ] Tap tab buttons → see subtle scale bounce
- [ ] Switch lanes → pill slides with bouncier spring
- [ ] Quick Add → success flash is snappier (300ms)
- [ ] Enable Reduce Motion → PressableButtonStyle has no animation, tab bounce is instant

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)