### PR TITLE
feat: end-to-end UI tests for core flows (#37)

### DIFF
--- a/idea-pilot/idea-pilot/App/idea_pilotApp.swift
+++ b/idea-pilot/idea-pilot/App/idea_pilotApp.swift
@@ -21,14 +21,44 @@ struct idea_pilotApp: App {
     let modelContainer: ModelContainer
     let tokenManager: TokenManager
     let apiClient: APIClient
-    let authService: AuthService
-    let playbookService: PlaybookService
-    let taskService: TaskService
-    let sectionService: SectionService
-    let weeklyPlanService: WeeklyPlanService
-    let syncEngine: SyncEngine
+    let authService: any AuthServiceProtocol
+    let playbookService: any PlaybookServiceProtocol
+    let taskService: any TaskServiceProtocol
+    let sectionService: any SectionServiceProtocol
+    let weeklyPlanService: any WeeklyPlanServiceProtocol
+    let syncEngine: SyncEngine?
 
     init() {
+        #if DEBUG
+        if ProcessInfo.processInfo.arguments.contains("UI_TEST_MODE") {
+            let container = try! ModelContainer(
+                for: PlaybookModel.self, MutationEntry.self,
+                configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+            )
+            let isSignedOut = ProcessInfo.processInfo.arguments.contains("UI_TEST_SIGNED_OUT")
+            let mockKeychain = UITestMockKeychainService()
+            if !isSignedOut {
+                try! mockKeychain.save("test-access", forKey: "com.lifeautomation.idea-pilot.accessToken")
+                try! mockKeychain.save("test-refresh", forKey: "com.lifeautomation.idea-pilot.refreshToken")
+                try! mockKeychain.save("uitest-1", forKey: "com.lifeautomation.idea-pilot.userId")
+                try! mockKeychain.save("test@example.com", forKey: "com.lifeautomation.idea-pilot.email")
+            }
+            let tm = TokenManager(keychain: mockKeychain, baseURL: URL(string: "https://test.api")!)
+            let client = APIClient(baseURL: URL(string: "https://test.api")!, tokenProvider: tm)
+
+            self.modelContainer = container
+            self.tokenManager = tm
+            self.apiClient = client
+            self.authService = UITestAuthService(tokenManager: tm)
+            self.playbookService = UITestPlaybookService()
+            self.taskService = UITestTaskService()
+            self.sectionService = UITestSectionService()
+            self.weeklyPlanService = UITestWeeklyPlanService()
+            self.syncEngine = nil
+            return
+        }
+        #endif
+
         let container = try! ModelContainer(for: PlaybookModel.self, MutationEntry.self)
         let tm = TokenManager(
             keychain: KeychainService(),
@@ -71,7 +101,7 @@ struct idea_pilotApp: App {
             RootView(tokenManager: tokenManager, authService: authService, playbookService: playbookService, taskService: taskService, sectionService: sectionService, weeklyPlanService: weeklyPlanService, syncEngine: syncEngine)
                 .onChange(of: scenePhase) { _, newPhase in
                     if newPhase == .active {
-                        syncEngine.onAppForeground()
+                        syncEngine?.onAppForeground()
                     }
                 }
         }

--- a/idea-pilot/idea-pilot/Core/Testing/UITestMockServices.swift
+++ b/idea-pilot/idea-pilot/Core/Testing/UITestMockServices.swift
@@ -1,0 +1,186 @@
+//
+//  UITestMockServices.swift
+//  idea-pilot
+//
+//  Mock services injected when the app launches with UI_TEST_MODE.
+//  Provides deterministic data for E2E UI tests.
+//
+
+#if DEBUG
+
+import Foundation
+
+// MARK: - Mock Keychain
+
+/// In-memory Keychain replacement for UI test mode.
+nonisolated final class UITestMockKeychainService: KeychainStorable, @unchecked Sendable {
+
+    nonisolated(unsafe) var storage: [String: String] = [:]
+
+    func save(_ value: String, forKey key: String) throws {
+        storage[key] = value
+    }
+
+    func load(forKey key: String) throws -> String? {
+        storage[key]
+    }
+
+    func delete(forKey key: String) throws {
+        storage.removeValue(forKey: key)
+    }
+}
+
+// MARK: - Mock Auth Service
+
+/// Always-succeeding auth service for UI tests.
+final class UITestAuthService: AuthServiceProtocol, Sendable {
+
+    private let tokenManager: TokenManager
+
+    init(tokenManager: TokenManager) {
+        self.tokenManager = tokenManager
+    }
+
+    func login(email: String, password: String) async throws -> UserSession {
+        let session = UserSession(
+            userId: "uitest-1",
+            email: email,
+            accessToken: "test-access",
+            refreshToken: "test-refresh"
+        )
+        try await tokenManager.storeSession(session)
+        return session
+    }
+
+    func register(email: String, password: String) async throws -> UserSession {
+        try await login(email: email, password: password)
+    }
+
+    func auth0Login(idToken: String) async throws -> UserSession {
+        try await login(email: "test@example.com", password: "")
+    }
+
+    func logout() async throws {
+        await tokenManager.clearTokens()
+    }
+}
+
+// MARK: - Mock Playbook Service
+
+/// Returns a single "Side Project" playbook for UI tests.
+struct UITestPlaybookService: PlaybookServiceProtocol {
+
+    nonisolated func fetchPlaybooks(updatedSince: Date?) async throws -> [PlaybookModel] {
+        [PlaybookModel(id: "pb-uitest", title: "Side Project", phase: .proof)]
+    }
+
+    nonisolated func createPlaybook(title: String, description: String?) async throws -> PlaybookModel {
+        PlaybookModel(id: "pb-new-\(UUID().uuidString.prefix(8))", title: title)
+    }
+
+    nonisolated func archivePlaybook(id: String) async throws {}
+}
+
+// MARK: - Mock Task Service
+
+/// Returns deterministic tasks for UI tests: 1 in Now, 2 in Next.
+struct UITestTaskService: TaskServiceProtocol {
+
+    nonisolated func fetchTasks(playbookId: String, lane: TaskLane?, updatedSince: Date?) async throws -> [TaskModel] {
+        let tasks = [
+            TaskModel(
+                id: "t-now-1",
+                playbookId: playbookId,
+                title: "Design landing page",
+                lane: .now,
+                estimatedMinutes: 60,
+                orderIndex: 0
+            ),
+            TaskModel(
+                id: "t-next-1",
+                playbookId: playbookId,
+                title: "Research competitors",
+                lane: .next,
+                estimatedMinutes: 90,
+                orderIndex: 0
+            ),
+            TaskModel(
+                id: "t-next-2",
+                playbookId: playbookId,
+                title: "Write copy",
+                lane: .next,
+                estimatedMinutes: 30,
+                orderIndex: 1
+            ),
+        ]
+
+        if let lane {
+            return tasks.filter { $0.lane == lane }
+        }
+        return tasks
+    }
+
+    nonisolated func createTask(playbookId: String, title: String, detail: String?, lane: TaskLane, estimatedMinutes: Int) async throws -> TaskModel {
+        TaskModel(
+            id: "t-new-\(UUID().uuidString.prefix(8))",
+            playbookId: playbookId,
+            title: title,
+            detail: detail,
+            lane: lane,
+            estimatedMinutes: estimatedMinutes,
+            orderIndex: 99
+        )
+    }
+
+    nonisolated func updateTask(id: String, dto: UpdateTaskDTO) async throws -> TaskModel {
+        TaskModel(playbookId: "pb-uitest", title: dto.title ?? "Updated")
+    }
+
+    nonisolated func completeTask(id: String) async throws -> TaskModel {
+        TaskModel(
+            id: id,
+            playbookId: "pb-uitest",
+            title: "Completed",
+            status: .done,
+            completedAt: .now
+        )
+    }
+
+    nonisolated func reorderTasks(playbookId: String, lane: TaskLane, taskIds: [String]) async throws {}
+
+    nonisolated func deleteTask(id: String) async throws {}
+}
+
+// MARK: - Mock Section Service
+
+/// Returns empty sections for UI tests.
+struct UITestSectionService: SectionServiceProtocol {
+
+    nonisolated func fetchSections(playbookId: String, updatedSince: Date?) async throws -> [SectionModel] { [] }
+
+    nonisolated func updateSection(playbookId: String, sectionType: SectionType, content: String) async throws -> SectionModel {
+        SectionModel(playbookId: playbookId, sectionType: sectionType, content: content)
+    }
+}
+
+// MARK: - Mock Weekly Plan Service
+
+/// Returns a fresh weekly cycle for UI tests.
+struct UITestWeeklyPlanService: WeeklyPlanServiceProtocol {
+
+    nonisolated func getWeeklyStatus(playbookId: String) async throws -> WeeklyCycleModel {
+        WeeklyCycleModel(playbookId: playbookId, weekStartDate: .now)
+    }
+
+    nonisolated func createWeeklyPlan(playbookId: String, taskIds: [String]) async throws -> WeeklyCycleModel {
+        WeeklyCycleModel(
+            playbookId: playbookId,
+            weekStartDate: .now,
+            totalCount: taskIds.count
+        )
+    }
+
+    nonisolated func fetchWeeklyCycles(playbookId: String) async throws -> [WeeklyCycleModel] { [] }
+}
+
+#endif

--- a/idea-pilot/idea-pilot/Features/Auth/Views/AuthView.swift
+++ b/idea-pilot/idea-pilot/Features/Auth/Views/AuthView.swift
@@ -104,6 +104,7 @@ struct AuthView: View {
             ) {
                 focusedField = .password
             }
+            .accessibilityIdentifier("auth_email_field")
 
             themedSecureField(
                 label: "PASSWORD",
@@ -120,6 +121,7 @@ struct AuthView: View {
                     focusedField = .confirmPassword
                 }
             }
+            .accessibilityIdentifier("auth_password_field")
 
             if !vm.isLoginMode {
                 themedSecureField(
@@ -133,6 +135,7 @@ struct AuthView: View {
                     focusedField = nil
                     vm.submit()
                 }
+                .accessibilityIdentifier("auth_confirm_password_field")
             }
         }
     }
@@ -165,6 +168,7 @@ struct AuthView: View {
         .accessibilityLabel(vm.isLoading
             ? (vm.isLoginMode ? "Signing in" : "Signing up")
             : (vm.isLoginMode ? "Sign In" : "Sign Up"))
+        .accessibilityIdentifier("auth_submit_button")
     }
 
     // MARK: - Mode Toggle
@@ -192,6 +196,7 @@ struct AuthView: View {
             .font(.theme.subheadline)
         }
         .accessibilityLabel(vm.isLoginMode ? "Switch to Sign Up" : "Switch to Sign In")
+        .accessibilityIdentifier("auth_mode_toggle")
     }
 
     // MARK: - Themed Text Field

--- a/idea-pilot/idea-pilot/Features/Playbooks/Views/PlaybookListView.swift
+++ b/idea-pilot/idea-pilot/Features/Playbooks/Views/PlaybookListView.swift
@@ -102,9 +102,11 @@ struct PlaybookListView: View {
                     syncEngine: syncEngine,
                     onArchive: { vm.archivePlaybook(id: playbook.id) }
                 )
+                .accessibilityIdentifier("playbook_row_\(playbook.id)")
             }
 
             NewPlaybookButton(onTap: { vm.showCreateSheet = true })
+                .accessibilityIdentifier("new_playbook_button")
                 .padding(.top, 4)
         }
     }
@@ -265,6 +267,7 @@ private struct CreatePlaybookSheet: View {
                                     .stroke(Color.theme.input, lineWidth: 1)
                             )
                             .accessibilityLabel("Playbook title")
+                            .accessibilityIdentifier("create_playbook_title")
                     }
 
                     // Description field
@@ -315,6 +318,7 @@ private struct CreatePlaybookSheet: View {
                     .disabled(isTitleEmpty)
                     .accessibilityLabel("Create playbook")
                     .accessibilityHint(isTitleEmpty ? "Enter a title first" : "Creates a new playbook")
+                    .accessibilityIdentifier("create_playbook_submit")
                 }
                 .padding(.horizontal, 24)
                 .padding(.top, 16)

--- a/idea-pilot/idea-pilot/Features/Tasks/Views/PlaybookHomeView.swift
+++ b/idea-pilot/idea-pilot/Features/Tasks/Views/PlaybookHomeView.swift
@@ -86,6 +86,7 @@ struct PlaybookHomeView: View {
                         .foregroundStyle(Color.theme.mutedForeground)
                 }
                 .accessibilityLabel("More options")
+                .accessibilityIdentifier("playbook_menu")
             }
         }
         .alert("Sync Error", isPresented: $showSyncError) {
@@ -336,6 +337,7 @@ private struct LaneSegmentedControl: View {
                 .buttonStyle(.plain)
                 .accessibilityLabel("\(lane.rawValue) lane, \(counts[lane] ?? 0) tasks")
                 .accessibilityAddTraits(selectedLane == lane ? .isSelected : [])
+                .accessibilityIdentifier("lane_\(lane.rawValue.lowercased())")
             }
         }
         .padding(4)
@@ -410,6 +412,7 @@ private struct TaskCardRow: View {
             + (showCheckbox ? ", double tap to complete" : "")
         )
         .accessibilityHint("Tap for details")
+        .accessibilityIdentifier("task_card_\(task.id)")
         .accessibilityAction(named: "Complete task") { onComplete() }
         .accessibilityAction(named: "Move to \(moveDestinations.first?.rawValue ?? "")") {
             if let dest = moveDestinations.first { onMove(dest) }
@@ -524,6 +527,7 @@ private struct TaskCardRow: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel(isCompleting ? "Completed" : "Complete task")
+        .accessibilityIdentifier("task_checkbox_\(task.id)")
     }
 
     // MARK: - Completion Animation

--- a/idea-pilot/idea-pilot/Features/Tasks/Views/QuickAddSheet.swift
+++ b/idea-pilot/idea-pilot/Features/Tasks/Views/QuickAddSheet.swift
@@ -128,6 +128,7 @@ struct QuickAddSheet: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Playbook: \(vm.selectedPlaybook?.title ?? "none selected")")
+        .accessibilityIdentifier("quickadd_playbook_picker")
     }
 
     // MARK: - Title Field
@@ -155,6 +156,7 @@ struct QuickAddSheet: View {
                 )
                 .submitLabel(.done)
                 .accessibilityLabel("Task title")
+                .accessibilityIdentifier("quickadd_title")
         }
     }
 
@@ -214,6 +216,7 @@ struct QuickAddSheet: View {
         .disabled(!vm.canSubmit)
         .accessibilityLabel(vm.addButtonTitle)
         .accessibilityHint(vm.canSubmit ? "Creates a new task" : "Enter a title first")
+        .accessibilityIdentifier("quickadd_submit")
     }
 
     // MARK: - Success Flash

--- a/idea-pilot/idea-pilot/Features/WeeklyPlan/Views/WeeklyPlanFlowView.swift
+++ b/idea-pilot/idea-pilot/Features/WeeklyPlan/Views/WeeklyPlanFlowView.swift
@@ -198,6 +198,7 @@ private struct ReviewStepView: View {
                 ) {
                     vm.applyDispositionsAndAdvance()
                 }
+                .accessibilityIdentifier("weekly_continue")
             }
             .padding(.horizontal, 24)
             .padding(.top, 16)
@@ -396,6 +397,7 @@ private struct SelectStepView: View {
                 ) {
                     vm.createPlanAndAdvance()
                 }
+                .accessibilityIdentifier("weekly_plan_week")
             }
             .padding(.horizontal, 24)
             .padding(.top, 16)
@@ -513,6 +515,7 @@ private struct SelectStepView: View {
                 .accessibilityLabel("\(task.title), \(task.estimatedMinutes) minutes")
                 .accessibilityAddTraits(isSelected ? .isSelected : [])
                 .accessibilityHint(isSelected ? "Tap to deselect" : "Tap to select")
+                .accessibilityIdentifier("weekly_task_\(task.id)")
             }
         }
     }
@@ -617,6 +620,7 @@ private struct ConfirmStepView: View {
                 ) {
                     onDismiss()
                 }
+                .accessibilityIdentifier("weekly_lets_go")
             }
             .padding(.horizontal, 24)
             .padding(.bottom, 32)

--- a/idea-pilot/idea-pilot/Navigation/MainTabView.swift
+++ b/idea-pilot/idea-pilot/Navigation/MainTabView.swift
@@ -184,6 +184,7 @@ private struct CustomTabBar: View {
         }
         .accessibilityLabel("\(tab.label) tab")
         .accessibilityAddTraits(selectedTab == tab ? .isSelected : [])
+        .accessibilityIdentifier("tab_\(tab.label.lowercased())")
     }
 
     // MARK: - Capture Button (Center)
@@ -202,6 +203,7 @@ private struct CustomTabBar: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel("Create new task")
+        .accessibilityIdentifier("tab_capture")
         .offset(y: -8)
     }
 }

--- a/idea-pilot/idea-pilotUITests/AuthFlowUITests.swift
+++ b/idea-pilot/idea-pilotUITests/AuthFlowUITests.swift
@@ -1,0 +1,62 @@
+//
+//  AuthFlowUITests.swift
+//  idea-pilotUITests
+//
+//  End-to-end test for the sign-in authentication flow.
+//  Launches in signed-out mode, fills in credentials,
+//  and verifies navigation to the main tab bar.
+//
+
+import XCTest
+
+final class AuthFlowUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testSignInFlow() throws {
+        let app = UITestApp.launch(signedOut: true)
+
+        // Wait for auth screen to appear.
+        let emailField = app.textFields["auth_email_field"]
+        XCTAssertTrue(emailField.waitForExistence(timeout: 5), "Email field should appear")
+
+        // Enter email.
+        emailField.tap()
+        emailField.typeText("test@example.com")
+
+        // Enter password — SecureField by default.
+        let passwordField = app.secureTextFields["auth_password_field"]
+        XCTAssertTrue(passwordField.waitForExistence(timeout: 2), "Password field should appear")
+        passwordField.tap()
+        passwordField.typeText("password123")
+
+        // Tap sign in.
+        let submitButton = app.buttons["auth_submit_button"]
+        XCTAssertTrue(submitButton.isEnabled, "Submit button should be enabled")
+        submitButton.tap()
+
+        // Verify we land on the main tab bar.
+        let nowTab = app.buttons["tab_now"]
+        XCTAssertTrue(nowTab.waitForExistence(timeout: 5), "Now tab should appear after sign in")
+    }
+
+    @MainActor
+    func testModeToggleToSignUp() throws {
+        let app = UITestApp.launch(signedOut: true)
+
+        let emailField = app.textFields["auth_email_field"]
+        XCTAssertTrue(emailField.waitForExistence(timeout: 5))
+
+        // Toggle to sign-up mode.
+        let modeToggle = app.buttons["auth_mode_toggle"]
+        XCTAssertTrue(modeToggle.exists, "Mode toggle should exist")
+        modeToggle.tap()
+
+        // Confirm password field should now appear.
+        let confirmField = app.secureTextFields["auth_confirm_password_field"]
+        XCTAssertTrue(confirmField.waitForExistence(timeout: 2), "Confirm password field should appear in sign-up mode")
+    }
+}

--- a/idea-pilot/idea-pilotUITests/CaptureFlowUITests.swift
+++ b/idea-pilot/idea-pilotUITests/CaptureFlowUITests.swift
@@ -1,0 +1,64 @@
+//
+//  CaptureFlowUITests.swift
+//  idea-pilotUITests
+//
+//  End-to-end test for the Quick Add (capture) flow.
+//  Taps the capture button, selects a playbook,
+//  enters a task title, and submits.
+//
+
+import XCTest
+
+final class CaptureFlowUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testQuickAddTask() throws {
+        let app = UITestApp.launch()
+
+        // Wait for main tab bar.
+        let captureButton = app.buttons["tab_capture"]
+        XCTAssertTrue(captureButton.waitForExistence(timeout: 5), "Capture button should appear")
+
+        // Open Quick Add sheet.
+        captureButton.tap()
+
+        // Wait for the title field to appear.
+        let titleField = app.textFields["quickadd_title"]
+        XCTAssertTrue(titleField.waitForExistence(timeout: 5), "Quick Add title field should appear")
+
+        // Select playbook from the picker menu.
+        let playbookPicker = app.otherElements["quickadd_playbook_picker"]
+        if playbookPicker.exists {
+            playbookPicker.tap()
+            // Tap the playbook option in the menu.
+            let playbookOption = app.buttons["Side Project"]
+            if playbookOption.waitForExistence(timeout: 2) {
+                playbookOption.tap()
+            }
+        }
+
+        // Enter a task title.
+        titleField.tap()
+        titleField.typeText("New test task")
+
+        // Submit.
+        let submitButton = app.buttons["quickadd_submit"]
+        XCTAssertTrue(submitButton.waitForExistence(timeout: 2), "Submit button should appear")
+        submitButton.tap()
+
+        // After submission, the form should clear (title field empties)
+        // and the sheet stays open for multi-capture.
+        // Give the success flash time to clear.
+        sleep(1)
+
+        let titleValue = titleField.value as? String ?? ""
+        XCTAssertTrue(
+            titleValue.isEmpty || titleValue == "What needs to happen?",
+            "Title field should be cleared after successful add"
+        )
+    }
+}

--- a/idea-pilot/idea-pilotUITests/ExecutionFlowUITests.swift
+++ b/idea-pilot/idea-pilotUITests/ExecutionFlowUITests.swift
@@ -1,0 +1,96 @@
+//
+//  ExecutionFlowUITests.swift
+//  idea-pilotUITests
+//
+//  End-to-end test for the task execution flow.
+//  Navigates to a playbook, verifies tasks appear,
+//  and completes a task via the checkbox.
+//
+
+import XCTest
+
+final class ExecutionFlowUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testNavigateToPlaybookAndViewTasks() throws {
+        let app = UITestApp.launch()
+
+        // Navigate to Playbooks tab.
+        let playbooksTab = app.buttons["tab_playbooks"]
+        XCTAssertTrue(playbooksTab.waitForExistence(timeout: 5), "Playbooks tab should appear")
+        playbooksTab.tap()
+
+        // Tap the "Side Project" playbook row.
+        let playbookRow = app.buttons["playbook_row_pb-uitest"]
+        XCTAssertTrue(playbookRow.waitForExistence(timeout: 5), "Side Project playbook should appear")
+        playbookRow.tap()
+
+        // Verify lane segments appear.
+        let nowLane = app.buttons["lane_now"]
+        XCTAssertTrue(nowLane.waitForExistence(timeout: 5), "Now lane segment should appear")
+
+        // Verify the Now task card is visible.
+        let taskCard = app.buttons["task_card_t-now-1"]
+        XCTAssertTrue(taskCard.waitForExistence(timeout: 3), "Task card should appear in Now lane")
+    }
+
+    @MainActor
+    func testCompleteTask() throws {
+        let app = UITestApp.launch()
+
+        // Navigate to Playbooks → Side Project.
+        let playbooksTab = app.buttons["tab_playbooks"]
+        XCTAssertTrue(playbooksTab.waitForExistence(timeout: 5))
+        playbooksTab.tap()
+
+        let playbookRow = app.buttons["playbook_row_pb-uitest"]
+        XCTAssertTrue(playbookRow.waitForExistence(timeout: 5))
+        playbookRow.tap()
+
+        // Wait for tasks to load.
+        let checkbox = app.buttons["task_checkbox_t-now-1"]
+        XCTAssertTrue(checkbox.waitForExistence(timeout: 5), "Task checkbox should appear")
+
+        // Tap the checkbox to complete the task.
+        checkbox.tap()
+
+        // The task should animate out. Wait a moment for the completion animation.
+        sleep(2)
+
+        // After completion, the task card should eventually disappear.
+        let taskCard = app.buttons["task_card_t-now-1"]
+        let disappeared = taskCard.waitForNonExistence(timeout: 5)
+        XCTAssertTrue(disappeared, "Completed task should disappear from the lane")
+    }
+
+    @MainActor
+    func testSwitchLanes() throws {
+        let app = UITestApp.launch()
+
+        // Navigate to Playbooks → Side Project.
+        let playbooksTab = app.buttons["tab_playbooks"]
+        XCTAssertTrue(playbooksTab.waitForExistence(timeout: 5))
+        playbooksTab.tap()
+
+        let playbookRow = app.buttons["playbook_row_pb-uitest"]
+        XCTAssertTrue(playbookRow.waitForExistence(timeout: 5))
+        playbookRow.tap()
+
+        // Start on Now lane — verify Now task visible.
+        let nowLane = app.buttons["lane_now"]
+        XCTAssertTrue(nowLane.waitForExistence(timeout: 5))
+
+        // Switch to Next lane.
+        let nextLane = app.buttons["lane_next"]
+        XCTAssertTrue(nextLane.exists, "Next lane segment should exist")
+        nextLane.tap()
+
+        // Verify Next lane tasks appear.
+        let nextTask = app.buttons["task_card_t-next-1"]
+        XCTAssertTrue(nextTask.waitForExistence(timeout: 3), "Next lane task should appear")
+    }
+}

--- a/idea-pilot/idea-pilotUITests/Helpers/UITestHelpers.swift
+++ b/idea-pilot/idea-pilotUITests/Helpers/UITestHelpers.swift
@@ -1,0 +1,28 @@
+//
+//  UITestHelpers.swift
+//  idea-pilotUITests
+//
+//  Shared helpers for launching the app in UI test mode
+//  with deterministic mock services.
+//
+
+import XCTest
+
+enum UITestApp {
+
+    /// Launches the app in UI test mode with mock services injected.
+    ///
+    /// - Parameter signedOut: When `true`, launches without pre-loaded
+    ///   auth tokens so the app shows the sign-in screen.
+    /// - Returns: The launched `XCUIApplication` instance.
+    @MainActor
+    static func launch(signedOut: Bool = false) -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments = ["UI_TEST_MODE"]
+        if signedOut {
+            app.launchArguments.append("UI_TEST_SIGNED_OUT")
+        }
+        app.launch()
+        return app
+    }
+}

--- a/idea-pilot/idea-pilotUITests/WeeklyPlanFlowUITests.swift
+++ b/idea-pilot/idea-pilotUITests/WeeklyPlanFlowUITests.swift
@@ -1,0 +1,70 @@
+//
+//  WeeklyPlanFlowUITests.swift
+//  idea-pilotUITests
+//
+//  End-to-end test for the 3-step weekly planning flow.
+//  Navigates to a playbook, opens the weekly plan,
+//  and steps through Review → Select → Confirm.
+//
+
+import XCTest
+
+final class WeeklyPlanFlowUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testWeeklyPlanFullFlow() throws {
+        let app = UITestApp.launch()
+
+        // Navigate to Playbooks → Side Project.
+        let playbooksTab = app.buttons["tab_playbooks"]
+        XCTAssertTrue(playbooksTab.waitForExistence(timeout: 5))
+        playbooksTab.tap()
+
+        let playbookRow = app.buttons["playbook_row_pb-uitest"]
+        XCTAssertTrue(playbookRow.waitForExistence(timeout: 5))
+        playbookRow.tap()
+
+        // Wait for PlaybookHomeView to load.
+        let nowLane = app.buttons["lane_now"]
+        XCTAssertTrue(nowLane.waitForExistence(timeout: 5))
+
+        // Open the overflow menu and tap "Weekly Plan".
+        let menuButton = app.buttons["playbook_menu"]
+        XCTAssertTrue(menuButton.waitForExistence(timeout: 3), "Overflow menu should exist")
+        menuButton.tap()
+
+        let weeklyPlanOption = app.buttons["Weekly Plan"]
+        XCTAssertTrue(weeklyPlanOption.waitForExistence(timeout: 3), "Weekly Plan menu option should appear")
+        weeklyPlanOption.tap()
+
+        // Step 1: Review — tap Continue.
+        let continueButton = app.buttons["weekly_continue"]
+        XCTAssertTrue(continueButton.waitForExistence(timeout: 5), "Continue button should appear on review step")
+        continueButton.tap()
+
+        // Step 2: Select — pick a task and tap "Plan Week".
+        let planWeekButton = app.buttons["weekly_plan_week"]
+        XCTAssertTrue(planWeekButton.waitForExistence(timeout: 5), "Plan Week button should appear on select step")
+
+        // Select a task if checkboxes are available.
+        let taskCheckbox = app.buttons["weekly_task_t-now-1"]
+        if taskCheckbox.waitForExistence(timeout: 3) {
+            taskCheckbox.tap()
+        }
+
+        planWeekButton.tap()
+
+        // Step 3: Confirm — tap "Let's Go".
+        let letsGoButton = app.buttons["weekly_lets_go"]
+        XCTAssertTrue(letsGoButton.waitForExistence(timeout: 5), "Let's Go button should appear on confirm step")
+        letsGoButton.tap()
+
+        // After dismissing the weekly plan flow, we should be back
+        // at PlaybookHomeView with lane segments visible.
+        XCTAssertTrue(nowLane.waitForExistence(timeout: 5), "Should return to PlaybookHome after weekly plan flow")
+    }
+}

--- a/idea-pilot/idea-pilotUITests/idea_pilotUITests.swift
+++ b/idea-pilot/idea-pilotUITests/idea_pilotUITests.swift
@@ -9,31 +9,8 @@ import XCTest
 
 final class idea_pilotUITests: XCTestCase {
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-
-        // In UI tests it is usually best to stop immediately when a failure occurs.
-        continueAfterFailure = false
-
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    @MainActor
-    func testExample() throws {
-        // UI tests must launch the application that they test.
-        let app = XCUIApplication()
-        app.launch()
-
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-
     @MainActor
     func testLaunchPerformance() throws {
-        // This measures how long it takes to launch your application.
         measure(metrics: [XCTApplicationLaunchMetric()]) {
             XCUIApplication().launch()
         }


### PR DESCRIPTION
## Summary
- Add UI test infrastructure with `UI_TEST_MODE` launch argument that injects deterministic mock services (`#if DEBUG`)
- Add accessibility identifiers to 6 view files for stable UI test element queries
- Create 4 E2E UI test suites: auth sign-in, quick-add capture, task execution, and weekly plan flow
- Clean up boilerplate UI test file, add shared `UITestApp.launch()` helper
- Make `SyncEngine` optional to support nil injection in test mode

## Test plan
- [x] `xcodebuild build` — zero errors (main + UI test targets)
- [x] All 293 unit tests pass (no regressions from `SyncEngine?` change)
- [x] UI test target compiles (`build-for-testing` succeeds)
- [ ] Run UI tests on simulator to validate all 4 flows pass

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)