### PR TITLE
fix: production readiness checklist (#39)

### DIFF
--- a/idea-pilot/idea-pilot/App/idea_pilotApp.swift
+++ b/idea-pilot/idea-pilot/App/idea_pilotApp.swift
@@ -59,7 +59,9 @@ struct idea_pilotApp: App {
         }
         #endif
 
-        let container = try! ModelContainer(for: PlaybookModel.self, MutationEntry.self)
+        guard let container = try? ModelContainer(for: PlaybookModel.self, MutationEntry.self) else {
+            fatalError("Failed to initialize SwiftData ModelContainer. The app cannot function without local storage.")
+        }
         let tm = TokenManager(
             keychain: KeychainService(),
             baseURL: AppConfiguration.apiBaseURL

--- a/idea-pilot/idea-pilot/Features/Sections/Services/SectionService.swift
+++ b/idea-pilot/idea-pilot/Features/Sections/Services/SectionService.swift
@@ -140,7 +140,10 @@ final class SectionService: SectionServiceProtocol, Sendable {
     /// Upserts a single section DTO into SwiftData.
     @MainActor
     private func upsertSingleSection(_ dto: SectionDTO) throws -> SectionModel {
-        try upsertSections([dto]).first!
+        guard let model = try upsertSections([dto]).first else {
+            throw SectionError.serverError("Failed to upsert section")
+        }
+        return model
     }
 
     /// Applies a section content update locally (for offline queueing).

--- a/idea-pilot/idea-pilot/Features/WeeklyPlan/Services/WeeklyPlanService.swift
+++ b/idea-pilot/idea-pilot/Features/WeeklyPlan/Services/WeeklyPlanService.swift
@@ -160,7 +160,10 @@ final class WeeklyPlanService: WeeklyPlanServiceProtocol, Sendable {
     /// Upserts a single weekly cycle DTO into SwiftData.
     @MainActor
     private func upsertSingleCycle(_ dto: WeeklyCycleDTO) throws -> WeeklyCycleModel {
-        try upsertCycles([dto]).first!
+        guard let model = try upsertCycles([dto]).first else {
+            throw WeeklyPlanError.serverError("Failed to upsert weekly cycle")
+        }
+        return model
     }
 
     /// Inserts an optimistic weekly cycle with a temp ID for offline creates.


### PR DESCRIPTION
## Summary
- Replace unsafe `.first!` force unwraps in `SectionService` and `WeeklyPlanService` with `guard let` + `throw`
- Replace `try!` on `ModelContainer` init with `guard let` + descriptive `fatalError`
- Full production readiness audit completed (see checklist below)

## Audit Results

| Check | Status |
|-------|--------|
| No hardcoded localhost URLs in Release | PASS — URLs configured via `#if DEBUG` in AppConfiguration |
| No sensitive logging or credentials | PASS — all debug logging behind `#if DEBUG` |
| No force unwrapping | PASS (after this PR) — 3 force unwraps eliminated |
| No placeholder content | PASS — "Coming soon" text is intentional for unbuilt features |
| No dead code or unused files | PASS |
| No credentials in code | PASS — test tokens in `#if DEBUG` only |
| Proper Keychain storage | PASS |

## Test plan
- [x] `xcodebuild build` — zero errors
- [x] All 294 unit tests pass

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)