### PR TITLE
#82 Build out Now tab — wire up PlaybookHome with Now lane

### DIFF
--- a/idea-pilot/idea-pilot/Features/Now/ViewModels/NowTabViewModel.swift
+++ b/idea-pilot/idea-pilot/Features/Now/ViewModels/NowTabViewModel.swift
@@ -1,0 +1,136 @@
+//
+//  NowTabViewModel.swift
+//  idea-pilot
+//
+//  ViewModel for the Now tab — resolves the last-viewed playbook
+//  and provides it to PlaybookHomeView, or shows an empty state.
+//
+
+import Foundation
+
+/// Drives the Now tab by resolving which playbook to display.
+///
+/// On load, fetches all playbooks and selects the last-viewed one
+/// (persisted in UserDefaults). If no last-viewed playbook is stored
+/// or it no longer exists, falls back to the first available playbook.
+/// If no playbooks exist at all, exposes an empty state for the UI.
+@Observable
+final class NowTabViewModel {
+
+    // MARK: - State
+
+    var playbook: PlaybookModel?
+    var isLoading = false
+    var error: String?
+    var showCreateSheet = false
+
+    // MARK: - Create Sheet State
+
+    var newPlaybookTitle = ""
+    var newPlaybookDescription = ""
+
+    // MARK: - Dependencies
+
+    private let playbookService: any PlaybookServiceProtocol
+
+    /// The UserDefaults key for the last-viewed playbook ID.
+    static let lastViewedPlaybookKey = "lastViewedPlaybookId"
+
+    // MARK: - Init
+
+    /// Creates a NowTabViewModel.
+    ///
+    /// - Parameter playbookService: The service for fetching playbooks.
+    init(playbookService: any PlaybookServiceProtocol) {
+        self.playbookService = playbookService
+    }
+
+    // MARK: - Actions
+
+    /// Loads playbooks and resolves the one to display on the Now tab.
+    ///
+    /// Resolution order:
+    /// 1. Last-viewed playbook ID from UserDefaults (if it still exists and is not archived)
+    /// 2. First non-archived playbook
+    /// 3. `nil` (empty state)
+    func loadPlaybook() {
+        error = nil
+        isLoading = true
+
+        Task {
+            defer { isLoading = false }
+
+            do {
+                let playbooks = try await playbookService.fetchPlaybooks(updatedSince: nil)
+                let active = playbooks.filter { !$0.isArchived }
+                resolvePlaybook(from: active)
+            } catch {
+                self.error = "Unable to load playbooks. Pull to refresh."
+            }
+        }
+    }
+
+    /// Refreshes playbooks. Async for `.refreshable`.
+    func refresh() async {
+        error = nil
+
+        do {
+            let playbooks = try await playbookService.fetchPlaybooks(updatedSince: nil)
+            let active = playbooks.filter { !$0.isArchived }
+            resolvePlaybook(from: active)
+        } catch {
+            self.error = "Unable to load playbooks. Pull to refresh."
+        }
+    }
+
+    /// Creates a new playbook and sets it as the active Now playbook.
+    func createPlaybook() {
+        let trimmed = newPlaybookTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        let desc = newPlaybookDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        Task {
+            do {
+                let created = try await playbookService.createPlaybook(
+                    title: trimmed,
+                    description: desc.isEmpty ? nil : desc
+                )
+                playbook = created
+                Self.saveLastViewedPlaybookId(created.id)
+                newPlaybookTitle = ""
+                newPlaybookDescription = ""
+                showCreateSheet = false
+            } catch {
+                self.error = "Failed to create playbook. Please try again."
+            }
+        }
+    }
+
+    // MARK: - Last Viewed Persistence
+
+    /// Saves the last-viewed playbook ID to UserDefaults.
+    static func saveLastViewedPlaybookId(_ id: String) {
+        UserDefaults.standard.set(id, forKey: lastViewedPlaybookKey)
+    }
+
+    /// Returns the last-viewed playbook ID, or `nil` if none is stored.
+    static func lastViewedPlaybookId() -> String? {
+        UserDefaults.standard.string(forKey: lastViewedPlaybookKey)
+    }
+
+    // MARK: - Private
+
+    /// Resolves which playbook to display from a list of active playbooks.
+    private func resolvePlaybook(from active: [PlaybookModel]) {
+        if let lastId = Self.lastViewedPlaybookId(),
+           let match = active.first(where: { $0.id == lastId }) {
+            playbook = match
+        } else if let first = active.first {
+            playbook = first
+            Self.saveLastViewedPlaybookId(first.id)
+        } else {
+            playbook = nil
+        }
+    }
+}

--- a/idea-pilot/idea-pilot/Features/Now/Views/NowTabView.swift
+++ b/idea-pilot/idea-pilot/Features/Now/Views/NowTabView.swift
@@ -1,0 +1,204 @@
+//
+//  NowTabView.swift
+//  idea-pilot
+//
+//  The Now tab content — shows PlaybookHomeView for the last-viewed playbook,
+//  or an empty state prompting the user to create their first playbook.
+//
+
+import SwiftUI
+
+/// The Now tab's root view.
+///
+/// Resolves the last-viewed playbook and renders `PlaybookHomeView` for it.
+/// If no playbooks exist, shows an empty state with a "Create Playbook" CTA.
+struct NowTabView: View {
+
+    @Bindable var vm: NowTabViewModel
+    let taskService: any TaskServiceProtocol
+    let sectionService: any SectionServiceProtocol
+    let weeklyPlanService: any WeeklyPlanServiceProtocol
+    let syncEngine: SyncEngine?
+    let onSignOut: () -> Void
+
+    var body: some View {
+        Group {
+            if vm.isLoading && vm.playbook == nil {
+                loadingView
+            } else if let playbook = vm.playbook {
+                PlaybookHomeView(vm: PlaybookHomeViewModel(
+                    playbook: playbook,
+                    taskService: taskService,
+                    sectionService: sectionService,
+                    weeklyPlanService: weeklyPlanService,
+                    syncEngine: syncEngine
+                ))
+            } else {
+                emptyState
+            }
+        }
+        .onAppear { vm.loadPlaybook() }
+        .sheet(isPresented: $vm.showCreateSheet) {
+            NowCreatePlaybookSheet(vm: vm)
+        }
+    }
+
+    // MARK: - Loading
+
+    private var loadingView: some View {
+        ZStack {
+            Color.theme.background
+                .ignoresSafeArea()
+
+            ProgressView()
+                .tint(Color.theme.mutedForeground)
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                if let error = vm.error {
+                    ErrorBannerView(message: error)
+                }
+
+                EmptyStateView(
+                    icon: "play.circle",
+                    title: "No playbooks yet",
+                    message: "Create your first playbook to start executing",
+                    actionTitle: "Create Playbook",
+                    onAction: { vm.showCreateSheet = true }
+                )
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 8)
+        }
+        .refreshable { await vm.refresh() }
+        .themeBackground()
+        .navigationTitle("Now")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    onSignOut()
+                } label: {
+                    Image(systemName: "rectangle.portrait.and.arrow.right")
+                        .foregroundStyle(Color.theme.mutedForeground)
+                }
+                .accessibilityLabel("Sign out")
+            }
+        }
+    }
+}
+
+// MARK: - Create Playbook Sheet
+
+/// Half-sheet for creating a playbook from the Now tab empty state.
+private struct NowCreatePlaybookSheet: View {
+
+    @Bindable var vm: NowTabViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    private var isTitleEmpty: Bool {
+        vm.newPlaybookTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("TITLE")
+                            .font(.theme.overline)
+                            .foregroundStyle(Color.theme.mutedForeground)
+                            .tracking(1.0)
+
+                        TextField("My new playbook", text: $vm.newPlaybookTitle)
+                            .font(.theme.bodyRegular)
+                            .foregroundStyle(Color.theme.foreground)
+                            .textInputAutocapitalization(.sentences)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 14)
+                            .background(Color.theme.secondary)
+                            .clipShape(RoundedRectangle(cornerRadius: .theme.radiusMd))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: .theme.radiusMd)
+                                    .stroke(Color.theme.input, lineWidth: 1)
+                            )
+                            .accessibilityLabel("Playbook title")
+                            .accessibilityIdentifier("now_create_playbook_title")
+                    }
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("DESCRIPTION")
+                            .font(.theme.overline)
+                            .foregroundStyle(Color.theme.mutedForeground)
+                            .tracking(1.0)
+
+                        Text("Optional")
+                            .font(.theme.caption)
+                            .foregroundStyle(Color.theme.mutedForeground)
+
+                        TextField("What's this playbook about?", text: $vm.newPlaybookDescription, axis: .vertical)
+                            .font(.theme.bodyRegular)
+                            .foregroundStyle(Color.theme.foreground)
+                            .lineLimit(3...6)
+                            .textInputAutocapitalization(.sentences)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 14)
+                            .background(Color.theme.secondary)
+                            .clipShape(RoundedRectangle(cornerRadius: .theme.radiusMd))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: .theme.radiusMd)
+                                    .stroke(Color.theme.input, lineWidth: 1)
+                            )
+                            .accessibilityLabel("Playbook description, optional")
+                    }
+
+                    Button {
+                        vm.createPlaybook()
+                    } label: {
+                        Text("Create")
+                            .font(.theme.body)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(Color.theme.primaryForeground)
+                            .frame(maxWidth: .infinity)
+                            .frame(minHeight: 50)
+                            .background(isTitleEmpty ? Color.theme.muted : Color.theme.primary)
+                            .clipShape(RoundedRectangle(cornerRadius: .theme.radiusMd))
+                            .shadow(
+                                color: isTitleEmpty ? .clear : Color.theme.primary.opacity(0.4),
+                                radius: 12, y: 4
+                            )
+                    }
+                    .buttonStyle(.pressable)
+                    .disabled(isTitleEmpty)
+                    .accessibilityLabel("Create playbook")
+                    .accessibilityHint(isTitleEmpty ? "Enter a title first" : "Creates a new playbook")
+                    .accessibilityIdentifier("now_create_playbook_submit")
+                }
+                .padding(.horizontal, 24)
+                .padding(.top, 16)
+            }
+            .scrollDismissesKeyboard(.interactively)
+            .navigationTitle("New Playbook")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") {
+                        vm.newPlaybookTitle = ""
+                        vm.newPlaybookDescription = ""
+                        vm.showCreateSheet = false
+                    }
+                    .foregroundStyle(Color.theme.mutedForeground)
+                }
+            }
+            .themeBackground()
+        }
+        .presentationDetents([.medium])
+        .presentationDragIndicator(.visible)
+        .presentationBackground(Color.theme.background)
+    }
+}

--- a/idea-pilot/idea-pilot/Features/Tasks/ViewModels/PlaybookHomeViewModel.swift
+++ b/idea-pilot/idea-pilot/Features/Tasks/ViewModels/PlaybookHomeViewModel.swift
@@ -130,7 +130,11 @@ final class PlaybookHomeViewModel {
     // MARK: - Actions
 
     /// Loads all tasks for this playbook on appear. Fires an async Task internally.
+    ///
+    /// Also persists this playbook as the last-viewed so the Now tab can restore it.
     func loadTasks() {
+        NowTabViewModel.saveLastViewedPlaybookId(playbook.id)
+
         error = nil
         isLoading = true
         showCelebration = false

--- a/idea-pilot/idea-pilot/Navigation/MainTabView.swift
+++ b/idea-pilot/idea-pilot/Navigation/MainTabView.swift
@@ -66,6 +66,7 @@ struct MainTabView: View {
 
     @State private var selectedTab: AppTab = .now
     @State private var playbookListVM: PlaybookListViewModel
+    @State private var nowTabVM: NowTabViewModel
     @State private var showQuickAddSheet = false
 
     init(playbookService: any PlaybookServiceProtocol, taskService: any TaskServiceProtocol, sectionService: any SectionServiceProtocol, weeklyPlanService: any WeeklyPlanServiceProtocol, tokenManager: TokenManager, authService: any AuthServiceProtocol, syncEngine: SyncEngine?, onSignOut: @escaping () -> Void) {
@@ -78,6 +79,7 @@ struct MainTabView: View {
         self.authService = authService
         self.syncEngine = syncEngine
         self._playbookListVM = State(initialValue: PlaybookListViewModel(playbookService: playbookService))
+        self._nowTabVM = State(initialValue: NowTabViewModel(playbookService: playbookService))
     }
 
     var body: some View {
@@ -108,7 +110,14 @@ struct MainTabView: View {
     private var tabContent: some View {
         ZStack {
             NavigationStack {
-                NowPlaceholderView(onSignOut: onSignOut)
+                NowTabView(
+                    vm: nowTabVM,
+                    taskService: taskService,
+                    sectionService: sectionService,
+                    weeklyPlanService: weeklyPlanService,
+                    syncEngine: syncEngine,
+                    onSignOut: onSignOut
+                )
             }
             .opacity(selectedTab == .now ? 1 : 0)
 
@@ -205,41 +214,6 @@ private struct CustomTabBar: View {
         .accessibilityLabel("Create new task")
         .accessibilityIdentifier("tab_capture")
         .offset(y: -8)
-    }
-}
-
-// MARK: - Placeholder Tab Views
-
-/// Placeholder for the Now tab content.
-private struct NowPlaceholderView: View {
-
-    var onSignOut: () -> Void
-
-    var body: some View {
-        ZStack {
-            Color.theme.background
-                .ignoresSafeArea()
-
-            VStack(spacing: 24) {
-                Text("Now")
-                    .font(.theme.largeTitle)
-                    .foregroundStyle(Color.theme.foreground)
-
-                Text("Coming soon")
-                    .font(.theme.subheadline)
-                    .foregroundStyle(Color.theme.mutedForeground)
-
-                Button {
-                    onSignOut()
-                } label: {
-                    Text("Sign Out")
-                        .font(.theme.body)
-                        .foregroundStyle(Color.theme.destructive)
-                }
-                .accessibilityLabel("Sign out")
-            }
-        }
-        .safeAreaPadding(.bottom, 72)
     }
 }
 

--- a/idea-pilot/idea-pilotTests/NowTabViewModelTests.swift
+++ b/idea-pilot/idea-pilotTests/NowTabViewModelTests.swift
@@ -1,0 +1,213 @@
+//
+//  NowTabViewModelTests.swift
+//  idea-pilotTests
+//
+//  Unit tests for NowTabViewModel — last-viewed playbook resolution,
+//  persistence, empty state, and create flow.
+//
+
+import Foundation
+import Testing
+@testable import idea_pilot
+
+// MARK: - NowTabViewModel Tests
+
+@Suite("NowTabViewModel", .serialized)
+struct NowTabViewModelTests {
+
+    // Clean up UserDefaults before each test.
+    init() {
+        UserDefaults.standard.removeObject(forKey: NowTabViewModel.lastViewedPlaybookKey)
+    }
+
+    // MARK: - Load / Resolution
+
+    @Test("loadPlaybook resolves first playbook when no last-viewed is stored")
+    @MainActor func loadResolvesFirstPlaybook() async throws {
+        let mockService = MockPlaybookService()
+        mockService.fetchResult = .success([
+            PlaybookModel(id: "pb-1", title: "First"),
+            PlaybookModel(id: "pb-2", title: "Second"),
+        ])
+        let vm = NowTabViewModel(playbookService: mockService)
+
+        vm.loadPlaybook()
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(vm.playbook?.id == "pb-1")
+        #expect(NowTabViewModel.lastViewedPlaybookId() == "pb-1")
+    }
+
+    @Test("loadPlaybook resolves last-viewed playbook from UserDefaults")
+    @MainActor func loadResolvesLastViewed() async throws {
+        NowTabViewModel.saveLastViewedPlaybookId("pb-2")
+
+        let mockService = MockPlaybookService()
+        mockService.fetchResult = .success([
+            PlaybookModel(id: "pb-1", title: "First"),
+            PlaybookModel(id: "pb-2", title: "Second"),
+        ])
+        let vm = NowTabViewModel(playbookService: mockService)
+
+        vm.loadPlaybook()
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(vm.playbook?.id == "pb-2")
+    }
+
+    @Test("loadPlaybook falls back to first when last-viewed no longer exists")
+    @MainActor func loadFallsBackWhenLastViewedDeleted() async throws {
+        NowTabViewModel.saveLastViewedPlaybookId("pb-deleted")
+
+        let mockService = MockPlaybookService()
+        mockService.fetchResult = .success([
+            PlaybookModel(id: "pb-1", title: "First"),
+        ])
+        let vm = NowTabViewModel(playbookService: mockService)
+
+        vm.loadPlaybook()
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(vm.playbook?.id == "pb-1")
+        #expect(NowTabViewModel.lastViewedPlaybookId() == "pb-1")
+    }
+
+    @Test("loadPlaybook skips archived playbooks")
+    @MainActor func loadSkipsArchived() async throws {
+        let mockService = MockPlaybookService()
+        mockService.fetchResult = .success([
+            PlaybookModel(id: "pb-archived", title: "Archived", isArchived: true),
+            PlaybookModel(id: "pb-active", title: "Active"),
+        ])
+        let vm = NowTabViewModel(playbookService: mockService)
+
+        vm.loadPlaybook()
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(vm.playbook?.id == "pb-active")
+    }
+
+    @Test("loadPlaybook falls back to first when last-viewed is archived")
+    @MainActor func loadFallsBackWhenLastViewedArchived() async throws {
+        NowTabViewModel.saveLastViewedPlaybookId("pb-archived")
+
+        let mockService = MockPlaybookService()
+        mockService.fetchResult = .success([
+            PlaybookModel(id: "pb-archived", title: "Archived", isArchived: true),
+            PlaybookModel(id: "pb-active", title: "Active"),
+        ])
+        let vm = NowTabViewModel(playbookService: mockService)
+
+        vm.loadPlaybook()
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(vm.playbook?.id == "pb-active")
+    }
+
+    // MARK: - Empty State
+
+    @Test("loadPlaybook sets nil playbook when no playbooks exist")
+    @MainActor func loadEmptyState() async throws {
+        let mockService = MockPlaybookService()
+        mockService.fetchResult = .success([])
+        let vm = NowTabViewModel(playbookService: mockService)
+
+        vm.loadPlaybook()
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(vm.playbook == nil)
+        #expect(vm.error == nil)
+    }
+
+    @Test("loadPlaybook sets nil playbook when all are archived")
+    @MainActor func loadAllArchived() async throws {
+        let mockService = MockPlaybookService()
+        mockService.fetchResult = .success([
+            PlaybookModel(id: "pb-1", title: "Archived", isArchived: true),
+        ])
+        let vm = NowTabViewModel(playbookService: mockService)
+
+        vm.loadPlaybook()
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(vm.playbook == nil)
+    }
+
+    // MARK: - Error Handling
+
+    @Test("loadPlaybook sets error on service failure")
+    @MainActor func loadError() async throws {
+        let mockService = MockPlaybookService()
+        mockService.fetchResult = .failure(.networkError("connection failed"))
+        let vm = NowTabViewModel(playbookService: mockService)
+
+        vm.loadPlaybook()
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(vm.error != nil)
+        #expect(vm.playbook == nil)
+    }
+
+    // MARK: - Refresh
+
+    @Test("refresh reloads and resolves playbooks")
+    @MainActor func refreshSuccess() async throws {
+        let mockService = MockPlaybookService()
+        mockService.fetchResult = .success([
+            PlaybookModel(id: "pb-1", title: "First"),
+        ])
+        let vm = NowTabViewModel(playbookService: mockService)
+
+        await vm.refresh()
+
+        #expect(vm.playbook?.id == "pb-1")
+        #expect(mockService.fetchCallCount == 1)
+    }
+
+    // MARK: - Create Playbook
+
+    @Test("createPlaybook creates and sets as active playbook")
+    @MainActor func createSuccess() async throws {
+        let mockService = MockPlaybookService()
+        let created = PlaybookModel(id: "pb-new", title: "New Playbook")
+        mockService.createResult = .success(created)
+        let vm = NowTabViewModel(playbookService: mockService)
+
+        vm.newPlaybookTitle = "New Playbook"
+        vm.newPlaybookDescription = "Description"
+        vm.showCreateSheet = true
+        vm.createPlaybook()
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(vm.playbook?.id == "pb-new")
+        #expect(vm.showCreateSheet == false)
+        #expect(vm.newPlaybookTitle == "")
+        #expect(vm.newPlaybookDescription == "")
+        #expect(NowTabViewModel.lastViewedPlaybookId() == "pb-new")
+    }
+
+    @Test("createPlaybook does nothing with empty title")
+    @MainActor func createEmptyTitle() async throws {
+        let mockService = MockPlaybookService()
+        let vm = NowTabViewModel(playbookService: mockService)
+
+        vm.newPlaybookTitle = "   "
+        vm.createPlaybook()
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(mockService.createCallCount == 0)
+    }
+
+    // MARK: - Persistence
+
+    @Test("saveLastViewedPlaybookId and lastViewedPlaybookId round-trip")
+    func persistenceRoundTrip() {
+        NowTabViewModel.saveLastViewedPlaybookId("pb-123")
+        #expect(NowTabViewModel.lastViewedPlaybookId() == "pb-123")
+    }
+
+    @Test("lastViewedPlaybookId returns nil when nothing is stored")
+    func persistenceNil() {
+        #expect(NowTabViewModel.lastViewedPlaybookId() == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- Replace `NowPlaceholderView` with fully functional `NowTabView` that shows `PlaybookHomeView`
- Resolve last-viewed playbook from UserDefaults on launch (falls back to first active playbook)
- Persist last-viewed playbook ID when any playbook is opened from either tab
- Empty state with "Create Playbook" CTA when no playbooks exist
- Filter out archived playbooks from Now tab resolution

## Files Changed
- **New:** `Features/Now/ViewModels/NowTabViewModel.swift` — playbook resolution, persistence, create flow
- **New:** `Features/Now/Views/NowTabView.swift` — Now tab UI with PlaybookHomeView or empty state
- **New:** `idea-pilotTests/NowTabViewModelTests.swift` — 13 unit tests
- **Modified:** `Navigation/MainTabView.swift` — replaced placeholder, removed `NowPlaceholderView`
- **Modified:** `Features/Tasks/ViewModels/PlaybookHomeViewModel.swift` — saves last-viewed on `loadTasks()`

## Test plan
- [x] 13 unit tests pass (resolution, fallback, archived, empty state, errors, create, persistence)
- [x] Full test suite passes (no regressions)
- [ ] Manual: Login → Now tab shows last-viewed playbook's Now lane
- [ ] Manual: No playbooks → empty state with Create Playbook button
- [ ] Manual: Open playbook from Playbooks tab → switch to Now tab → same playbook shown
- [ ] Manual: Archive last-viewed playbook → Now tab falls back to next available

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)